### PR TITLE
chore: update default port from 3000 to 3001

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,9 @@ async function bootstrap() {
   const logger = new Logger('main.ts');
   logger.log(`NODE_VERSION: ${process.versions.node}`);
 
-  await app.listen(env.PORT || 3000);
+  await app.listen(env.PORT || 3001);
 
-  logger.log(`MMPS service is running on http://localhost:${env.PORT || 3000}/api - NODE_VERSION: ${process.versions.node}`);
+  logger.log(`MMPS service is running on http://localhost:${env.PORT || 3001}/api - NODE_VERSION: ${process.versions.node}`);
 }
 
 bootstrap();


### PR DESCRIPTION
## Description
This PR updates the default port in `src/main.ts` from 3000 to 3001.

## Changes
- Updated default port from `3000` to `3001` in two places:
  - `app.listen(env.PORT || 3001)`
  - Logger message showing the running port

## Impact
- The application will now default to port 3001 when no PORT environment variable is set
- This change helps avoid conflicts with other services that commonly use port 3000