### PR TITLE
feat(secretary): always summarize her messages in reply drafts

### DIFF
--- a/src/features/secretary/scripts/test-draft.ts
+++ b/src/features/secretary/scripts/test-draft.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { userPrompt, wantSummary } = buildDraftUserPrompt(messages, unanswered);
+  const { userPrompt, wantSummary } = buildDraftUserPrompt(messages);
 
   logger.log('────────────── PROMPT SENT TO MODEL ──────────────');
   logger.log(`\n${userPrompt}\n`);

--- a/src/features/secretary/secretary-draft.utils.ts
+++ b/src/features/secretary/secretary-draft.utils.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { GPT_5_MODEL } from '@services/openai/constants';
 import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
 import type { SecretaryMessage } from './mongo';
-import { DRAFT_GENERATION_PROMPT, DRAFT_OPTIONS_COUNT, OWNER_NAME, SUMMARY_CHAR_THRESHOLD } from './secretary.config';
+import { DRAFT_GENERATION_PROMPT, DRAFT_OPTIONS_COUNT, OWNER_NAME } from './secretary.config';
 
 export type DraftReply = {
   readonly drafts: string[]; // distinct ready-to-send reply options, best-guess first
@@ -19,7 +19,7 @@ const draftSchema = z.object({
     .min(1)
     .max(6)
     .describe(`Exactly ${DRAFT_OPTIONS_COUNT} DISTINCT reply options for the owner to choose from, best-guess first. Each option must be meaningfully different in angle/tone, not a reworded duplicate.`),
-  summary: z.string().describe('A one-line summary of what she talked about, or an empty string if her messages were short'),
+  summary: z.string().describe('A one-line summary of what she talked about'),
   replyNeeded: z.number().min(0).max(1).describe('Probability (0 to 1) that the owner actually needs to reply: low for acknowledgements/closings, high for questions/requests/plans'),
 });
 
@@ -34,14 +34,12 @@ export function unansweredTail(messages: SecretaryMessage[]): SecretaryMessage[]
 }
 
 // Assemble the user prompt fed to the draft model from the recent conversation.
-export function buildDraftUserPrompt(context: SecretaryMessage[], unanswered: SecretaryMessage[]): { userPrompt: string; wantSummary: boolean } {
+export function buildDraftUserPrompt(context: SecretaryMessage[]): { userPrompt: string; wantSummary: boolean } {
   const other = context.find((m) => !m.fromOwner);
   const otherName = other?.senderName || other?.senderUsername || 'her';
   const transcript = context.map((m) => `${m.fromOwner ? OWNER_NAME : otherName}: ${m.text}`).join('\n');
-  const unansweredText = unanswered.map((m) => m.text).join(' ');
-  const wantSummary = unansweredText.length >= SUMMARY_CHAR_THRESHOLD;
-  const userPrompt = `Recent conversation (most recent last):\n\n${transcript}\n\nWrite ${DRAFT_OPTIONS_COUNT} distinct reply options ${OWNER_NAME} could send to her latest unanswered messages.${wantSummary ? '' : ' Her messages are short, so leave "summary" empty.'}`;
-  return { userPrompt, wantSummary };
+  const userPrompt = `Recent conversation (most recent last):\n\n${transcript}\n\nWrite ${DRAFT_OPTIONS_COUNT} distinct reply options ${OWNER_NAME} could send to her latest unanswered messages. Always include a one-line "summary" of what she talked about.`;
+  return { userPrompt, wantSummary: true };
 }
 
 const buildModel = () => {
@@ -52,8 +50,7 @@ const buildModel = () => {
 
 // Generate distinct reply options for the given recent conversation in a single call. Returns null if none produced.
 export async function generateDraftReply(context: SecretaryMessage[]): Promise<DraftReply | null> {
-  const unanswered = unansweredTail(context);
-  const { userPrompt, wantSummary } = buildDraftUserPrompt(context, unanswered);
+  const { userPrompt, wantSummary } = buildDraftUserPrompt(context);
 
   const structured = buildModel().withStructuredOutput(draftSchema, { name: 'smart_reply_draft' });
   const usageHandler = new UsageCallbackHandler();

--- a/src/features/secretary/secretary.config.ts
+++ b/src/features/secretary/secretary.config.ts
@@ -26,9 +26,6 @@ export const IDLE_REPLY_DELAY_MS = 5 * 60 * 1000;
 // Smart reply drafts: how many distinct options to offer per suggestion (all produced in a single LLM call).
 export const DRAFT_OPTIONS_COUNT = Math.min(4, Math.max(2, Number(env.SECRETARY_DRAFT_OPTIONS ?? 4)));
 
-// Only include a "what she talked about" summary when her unanswered text is at least this long.
-export const SUMMARY_CHAR_THRESHOLD = 300;
-
 // Smart reply drafts: skip sending a draft if the model's reply-needed probability is below this.
 export const REPLY_NEEDED_THRESHOLD = 0.6;
 


### PR DESCRIPTION
## Summary

The secretary's smart-reply suggestion card only showed the `📋 She talked about: …` summary when her unanswered messages totaled ≥ 300 characters. This makes the summary **always** appear.

## Changes
- `secretary-draft.utils.ts` — `buildDraftUserPrompt` always sets `wantSummary: true` and always instructs the model to include a one-line summary. Removed the now-unused `unanswered` param/var and tightened the schema description.
- `secretary.config.ts` — removed the now-unused `SUMMARY_CHAR_THRESHOLD`.
- `scripts/test-draft.ts` — updated caller for the new signature.

## Verification
- `npx tsc --noEmit` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>