### PR TITLE
feat(secretary): restrict reply suggestions to Mon–Thu

### DIFF
--- a/src/features/secretary/secretary-draft.service.ts
+++ b/src/features/secretary/secretary-draft.service.ts
@@ -4,7 +4,7 @@ import { MY_USER_ID } from '@core/config';
 import { Logger } from '@core/utils';
 import { buildInlineKeyboard } from '@services/telegram';
 import { createDraft, getDraftByShortId, getRecentMessagesForChat, setDraftMessageId, supersedePendingDraftsForChat, updateDraftStatus } from './mongo';
-import { generateDraftReply, unansweredTail } from './secretary-draft.utils';
+import { generateDraftReply, isSuggestionActiveDay, unansweredTail } from './secretary-draft.utils';
 import { DRAFT_CANCEL_CALLBACK_PREFIX, DRAFT_SEND_CALLBACK_PREFIX, IDLE_REPLY_DELAY_MS, OWNER_BUSINESS_CONNECTION_ID, REPLY_NEEDED_THRESHOLD } from './secretary.config';
 import { SecretaryService } from './secretary.service';
 
@@ -57,6 +57,11 @@ export class SecretaryDraftService {
   }
 
   private async suggestDraft(chatId: number, options: { respectReplyNeeded: boolean } = { respectReplyNeeded: true }): Promise<void> {
+    if (!isSuggestionActiveDay()) {
+      this.logger.log(`Skipping draft for ${chatId}: suggestions are inactive today.`);
+      return;
+    }
+
     const messages = await getRecentMessagesForChat(chatId, CONTEXT_MESSAGE_LIMIT);
     if (messages.length === 0) return;
 

--- a/src/features/secretary/secretary-draft.service.ts
+++ b/src/features/secretary/secretary-draft.service.ts
@@ -158,7 +158,8 @@ export class SecretaryDraftService {
     }
   }
 
-  async handleCancel(ctx: Context): Promise<void> {
+  // Returns the cancelled draft's chatId (or null) so the caller can also stand down the nudge for that chat.
+  async handleCancel(ctx: Context): Promise<number | null> {
     const shortId = (ctx.callbackQuery?.data ?? '').slice(DRAFT_CANCEL_CALLBACK_PREFIX.length);
     const draft = await getDraftByShortId(shortId);
     if (draft && draft.status === 'pending') await updateDraftStatus(shortId, 'cancelled');
@@ -169,5 +170,6 @@ export class SecretaryDraftService {
       this.logger.error(`Failed to remove draft buttons: ${err}`);
     }
     await ctx.answerCallbackQuery({ text: 'Dismissed' });
+    return draft?.chatId ?? null;
   }
 }

--- a/src/features/secretary/secretary-draft.utils.ts
+++ b/src/features/secretary/secretary-draft.utils.ts
@@ -1,11 +1,13 @@
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
+import { toZonedTime } from 'date-fns-tz';
 import { env } from 'node:process';
 import { z } from 'zod';
+import { DEFAULT_TIMEZONE } from '@core/config';
 import { GPT_5_MODEL } from '@services/openai/constants';
 import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
 import type { SecretaryMessage } from './mongo';
-import { DRAFT_GENERATION_PROMPT, DRAFT_OPTIONS_COUNT, OWNER_NAME } from './secretary.config';
+import { DRAFT_GENERATION_PROMPT, DRAFT_OPTIONS_COUNT, OWNER_NAME, SUGGESTION_ACTIVE_WEEKDAYS } from './secretary.config';
 
 export type DraftReply = {
   readonly drafts: string[]; // distinct ready-to-send reply options, best-guess first
@@ -33,6 +35,12 @@ export function unansweredTail(messages: SecretaryMessage[]): SecretaryMessage[]
     tail.unshift(messages[i]);
   }
   return tail;
+}
+
+// Whether smart-reply suggestions / nudges are active right now (Mon–Thu in Asia/Jerusalem).
+export function isSuggestionActiveDay(now: Date = new Date()): boolean {
+  const weekday = toZonedTime(now, DEFAULT_TIMEZONE).getDay();
+  return SUGGESTION_ACTIVE_WEEKDAYS.includes(weekday);
 }
 
 // Assemble the user prompt fed to the draft model from the recent conversation.

--- a/src/features/secretary/secretary-nudge.service.ts
+++ b/src/features/secretary/secretary-nudge.service.ts
@@ -5,7 +5,7 @@ import { Logger } from '@core/utils';
 import { buildInlineKeyboard } from '@services/telegram';
 import { createNudge, getNudgeByShortId, getRecentMessagesForChat, type SecretaryMessage, setNudgeMessageId, supersedePendingNudgesForChat, updateNudgeStatus } from './mongo';
 import { SecretaryDraftService } from './secretary-draft.service';
-import { generateDraftReply } from './secretary-draft.utils';
+import { generateDraftReply, isSuggestionActiveDay } from './secretary-draft.utils';
 import { NUDGE_DELAY_MS, NUDGE_DISMISS_CALLBACK_PREFIX, NUDGE_REPLY_CALLBACK_PREFIX, NUDGE_SNOOZE_CALLBACK_PREFIX, REPLY_NEEDED_THRESHOLD } from './secretary.config';
 
 const CONTEXT_MESSAGE_LIMIT = 20;
@@ -49,6 +49,11 @@ export class SecretaryNudgeService {
   }
 
   private async sendNudge(chatId: number): Promise<void> {
+    if (!isSuggestionActiveDay()) {
+      this.logger.log(`Skipping nudge for ${chatId}: suggestions are inactive today.`);
+      return;
+    }
+
     const messages = await getRecentMessagesForChat(chatId, CONTEXT_MESSAGE_LIMIT);
     if (messages.length === 0) return;
 

--- a/src/features/secretary/secretary.config.ts
+++ b/src/features/secretary/secretary.config.ts
@@ -23,6 +23,11 @@ export const ACTION_CALLBACK_PREFIX = 'sec:act:';
 // Smart reply drafts: after the other side goes unanswered for this long, suggest a draft reply.
 export const IDLE_REPLY_DELAY_MS = 5 * 60 * 1000;
 
+// Days of week (0 = Sunday .. 6 = Saturday, Asia/Jerusalem) the smart-reply suggestions and
+// forgotten-reply nudges are active. Everything else is suppressed to avoid wasteful runs.
+// The daily summary is unaffected and still runs every day.
+export const SUGGESTION_ACTIVE_WEEKDAYS = [1, 2, 3, 4]; // Monday, Tuesday, Wednesday, Thursday
+
 // Smart reply drafts: how many distinct options to offer per suggestion (all produced in a single LLM call).
 export const DRAFT_OPTIONS_COUNT = Math.min(4, Math.max(2, Number(env.SECRETARY_DRAFT_OPTIONS ?? 4)));
 

--- a/src/features/secretary/secretary.controller.ts
+++ b/src/features/secretary/secretary.controller.ts
@@ -177,7 +177,9 @@ export class SecretaryController {
       await ctx.answerCallbackQuery();
       return;
     }
-    await this.draftService.handleCancel(ctx);
+    // Cancelling a suggestion also stands down the 1-hour forgotten-reply nudge for that chat.
+    const chatId = await this.draftService.handleCancel(ctx);
+    if (chatId !== null) await this.nudgeService.onOwnerReply(chatId);
   }
 
   private async nudgeReplyHandler(ctx: Context): Promise<void> {


### PR DESCRIPTION
## What

The secretary bot's smart-reply feature watches the wife's chat and, after 5 minutes of no owner reply, generates draft reply suggestions (plus a 1-hour "forgotten reply" nudge). Until now this ran **every day**, which is a bit wasteful.

This change restricts those **suggestions and nudges to Monday–Thursday** (`Asia/Jerusalem`). On all other days (Fri/Sat/Sun) they are suppressed.

The **daily summary is unaffected** and continues to run every day.

## How

- Added `SUGGESTION_ACTIVE_WEEKDAYS = [1, 2, 3, 4]` to `secretary.config.ts`.
- Added `isSuggestionActiveDay()` helper in `secretary-draft.utils.ts` (timezone-aware via `date-fns-tz` + `DEFAULT_TIMEZONE`).
- Gated `SecretaryDraftService.suggestDraft()` and `SecretaryNudgeService.sendNudge()` on the active-day check. Gating happens at **timer-fire time** (not scheduling time), so timers set just before midnight respect the actual day they fire on. This also covers the nudge's "Reply ✍️" button path, since the nudge itself won't fire on inactive days.

## Validation

- `tsc --noEmit` passes.
- `eslint` passes on all changed files.

No visible UI impact.