### PR TITLE
feat(savings): filter holdings by any geography percentage

### DIFF
--- a/apps/savings-web/src/components/HoldingsTable.tsx
+++ b/apps/savings-web/src/components/HoldingsTable.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { effectiveGeography } from '../lib/breakdown';
 import { formatIls, formatPercent } from '../lib/format';
 import type { BreakdownRecord, Holding } from '../types';
 import { GEOGRAPHY_LABELS } from '../types';
@@ -97,12 +98,16 @@ function hasActiveFilters(filters: FilterState): boolean {
   return filters.owner.size > 0 || filters.account.size > 0 || filters.currency.size > 0 || filters.asset.size > 0 || filters.geography.size > 0;
 }
 
+function holdingGeographies(holding: Holding): readonly string[] {
+  return [...effectiveGeography(holding).keys()];
+}
+
 function matchesFilters(holding: Holding, filters: FilterState): boolean {
   if (filters.owner.size > 0 && !filters.owner.has(holding.owner)) return false;
   if (filters.account.size > 0 && !filters.account.has(holding.account)) return false;
   if (filters.currency.size > 0 && !filters.currency.has(holding.currencyExposure)) return false;
   if (filters.asset.size > 0 && !filters.asset.has(holding.assetType)) return false;
-  if (filters.geography.size > 0 && !filters.geography.has(holding.geography)) return false;
+  if (filters.geography.size > 0 && !holdingGeographies(holding).some((geo) => filters.geography.has(geo))) return false;
   return true;
 }
 
@@ -140,7 +145,7 @@ export function HoldingsTable({ holdings, editable, onAmountChange, onRowClick }
   const activeGeographies = useMemo(() => {
     const set = new Set<string>();
     for (const h of holdings) {
-      if (h.geography) set.add(h.geography);
+      for (const geo of holdingGeographies(h)) set.add(geo);
     }
     return [...set].sort((a, b) => {
       const ai = (GEOGRAPHY_LABELS as readonly string[]).indexOf(a);


### PR DESCRIPTION
## Summary

The savings app's **area (אזור) filter** previously matched only holdings whose single primary geography equalled the selected area. Holdings that hold a partial percentage of that area via their geographyBreakdown (e.g. 40% אירופה) were excluded.

Now the filter matches a holding if **any positive percentage** of the selected area appears in its geography breakdown, falling back to the single primary area when a holding has no breakdown.

## Changes

- apps/savings-web/src/components/HoldingsTable.tsx
  - Added holdingGeographies() helper backed by the existing effectiveGeography() lib, which returns all areas a holding is exposed to (breakdown entries with value > 0, or the single primary area).
  - matchesFilters() now checks whether any of a holding's effective geographies is selected.
  - activeGeographies (the filter chips) now surfaces every area that appears in any breakdown, not just primary areas.

## Validation

- npm run build (savings-web) — passes
- npm test (savings-web) — 35 tests pass