### PR TITLE
feat(savings): improve deposit advisor targeting

### DIFF
--- a/apps/savings-web/src/components/DepositAdvisorModal.tsx
+++ b/apps/savings-web/src/components/DepositAdvisorModal.tsx
@@ -91,7 +91,7 @@ export function DepositAdvisorModal({ holdings, settings, onApply, onClose }: De
             ) : candidates.length === 0 ? (
               <div className="empty-content compact">
                 <strong>אין השקעות להצגה</strong>
-                <span>יש להוסיף השקעה קיימת לפני שימוש ביעוץ ההפקדה.</span>
+                <span>ההמלצות ניתנות רק להשקעות שחלקן בתיק מוגדר כ״ידני״. יש להוסיף השקעה כזו לפני שימוש ביעוץ ההפקדה.</span>
               </div>
             ) : (
               <ul className="advisor-candidate-list">

--- a/apps/savings-web/src/lib/allocationAdvisor.spec.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.spec.ts
@@ -79,10 +79,10 @@ describe('distanceToTargets()', () => {
     expect(distanceToTargets(farOneCategory, settings, ['ישראל', 'ארהב'])).toBeGreaterThan(distanceToTargets(closeTwoCategories, settings, ['ישראל', 'ארהב']));
   });
 
-  it('uses the single worst region gap for the geography category', () => {
+  it('sums every region gap for the geography category', () => {
     const oneRegionFar: PortfolioExposure = { fxPercent: 50, solidPercent: 50, geographyPercent: new Map([['ישראל', 70], ['ארהב', 30]]) };
-    // Worst region gap is 20 → 400; fx and solid contribute nothing.
-    expect(distanceToTargets(oneRegionFar, settings, ['ישראל', 'ארהב'])).toBeCloseTo(400);
+    // ישראל 20 over + ארהב 20 under = summed geography gap 40 → 40^2 = 1600; fx and solid contribute nothing.
+    expect(distanceToTargets(oneRegionFar, settings, ['ישראל', 'ארהב'])).toBeCloseTo(1600);
   });
 });
 
@@ -121,34 +121,59 @@ describe('rankCandidates()', () => {
   });
 
   it('prioritizes the manual holding that closes the farthest category first', () => {
-    // fx is 30% off target (far); geography is only ~7% off (near). The manual holding that fixes
-    // the far fx gap should rank ahead of one that only nudges the already-near geography split.
+    // fx is far from target; geography is balanced (near). The manual holding that fixes the far fx
+    // gap should rank ahead of one that only nudges the already-near geography split.
+    // Before: fx 20%, solid 100%, ישראל 50%, ארהב 50%. Targets fx 50, solid 100, geo 50/50.
+    // → fx gap 30 (far), solid 0, geo 0 (near). fx is the single farthest category.
+    const balancedSettings: PortfolioSettings = { ...settings, fxLimitPercent: 50, solidTargetPercent: 100, geographyTargets: { ישראל: 50, ארהב: 50 } };
     const holdings = [
-      holding({ id: 'ils-anchor', account: 'managed', currentAmountIls: 80, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
-      holding({ id: 'fx-fixer', account: 'manual', currentAmountIls: 20, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
-      holding({ id: 'geo-nudger', account: 'manual', currentAmountIls: 20, currencyExposure: 'ils', assetType: 'solid', geography: 'ארהב' }),
+      holding({ id: 'ils-anchor-il', account: 'managed', currentAmountIls: 40, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
+      holding({ id: 'ils-anchor-us', account: 'managed', currentAmountIls: 40, currencyExposure: 'ils', assetType: 'solid', geography: 'ארהב' }),
+      holding({ id: 'fx-fixer', account: 'manual', currentAmountIls: 10, currencyExposure: 'fx', assetType: 'solid', geography: 'ישראל' }),
+      holding({ id: 'geo-nudger', account: 'manual', currentAmountIls: 10, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
     ];
-    const ranked = rankCandidates(holdings, settings, 60, 3);
+    const ranked = rankCandidates(holdings, balancedSettings, 60, 3);
     expect(ranked[0]?.holding.id).toEqual('fx-fixer');
   });
 
   it('does not rank a holding that worsens the dominant category, even if it helps smaller gaps', () => {
-    // Dominant gap is geography ישראל: 60% vs 25% target (gap 35). fx is only 5% off.
-    // 'israel-fx' improves fx but pushes ישראל further over target -> must not rank first.
-    // 'us-fixer' pulls ישראל down toward target -> should rank first.
+    // Dominant category is geography: ישראל 60% vs 25% target dominates the summed geo gap.
+    // 'israel-fx' pushes ישראל further over target -> worsens the dominant category -> must not rank
+    // first. 'europe-fixer' fills an under-target region (אירופה at 0% vs 25%) and pulls ישראל down,
+    // improving the geography category -> should rank first.
     const geoSettings: PortfolioSettings = { ...settings, fxLimitPercent: 65, solidTargetPercent: 0, geographyTargets: { ישראל: 25, ארהב: 25, אסיה: 25, אירופה: 25 } };
     const holdings = [
       holding({ id: 'israel-anchor', account: 'managed', currentAmountIls: 60, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
       holding({ id: 'us-anchor', account: 'managed', currentAmountIls: 20, currencyExposure: 'ils', assetType: 'equity', geography: 'ארהב' }),
       holding({ id: 'asia-anchor', account: 'managed', currentAmountIls: 20, currencyExposure: 'fx', assetType: 'equity', geography: 'אסיה' }),
       holding({ id: 'israel-fx', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
-      holding({ id: 'us-fixer', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'equity', geography: 'ארהב' }),
+      holding({ id: 'europe-fixer', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'equity', geography: 'אירופה' }),
     ];
     const ranked = rankCandidates(holdings, geoSettings, 40, 3);
-    expect(ranked[0]?.holding.id).toEqual('us-fixer');
+    expect(ranked[0]?.holding.id).toEqual('europe-fixer');
     expect(ranked[0]?.primaryImprovement).toBeGreaterThan(0);
     // The ישראל holding worsens the dominant geography gap -> negative primary improvement.
     const israelCandidate = ranked.find((candidate) => candidate.holding.id === 'israel-fx');
     expect(israelCandidate?.primaryImprovement ?? 0).toBeLessThan(0);
+  });
+
+  it('prefers an under-target region over an already-over-target one when both shrink the worst region', () => {
+    // Geography before: ישראל 43 (target 25, way over), ארהב 43 (target 35, over), אסיה 8 (target 20,
+    // under), אירופה 6 (target 20, under). Both a USA and an Asia deposit shrink ישראל's share about
+    // equally, but USA is already over its own target while Asia is under. The Asia holding must win.
+    const geoSettings: PortfolioSettings = { ...settings, fxLimitPercent: 50, solidTargetPercent: 100, geographyTargets: { ישראל: 25, ארהב: 35, אסיה: 20, אירופה: 20 } };
+    const holdings = [
+      holding({ id: 'israel-anchor', account: 'managed', currentAmountIls: 43, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
+      holding({ id: 'us-anchor', account: 'managed', currentAmountIls: 43, currencyExposure: 'fx', assetType: 'solid', geography: 'ארהב' }),
+      holding({ id: 'asia-anchor', account: 'managed', currentAmountIls: 8, currencyExposure: 'fx', assetType: 'solid', geography: 'אסיה' }),
+      holding({ id: 'europe-anchor', account: 'managed', currentAmountIls: 6, currencyExposure: 'fx', assetType: 'solid', geography: 'אירופה' }),
+      holding({ id: 'us-manual', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'solid', geography: 'ארהב' }),
+      holding({ id: 'asia-manual', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'solid', geography: 'אסיה' }),
+    ];
+    const ranked = rankCandidates(holdings, geoSettings, 20, 3);
+    expect(ranked[0]?.holding.id).toEqual('asia-manual');
+    const usCandidate = ranked.find((candidate) => candidate.holding.id === 'us-manual');
+    const asiaCandidate = ranked.find((candidate) => candidate.holding.id === 'asia-manual');
+    expect(asiaCandidate?.primaryImprovement ?? 0).toBeGreaterThan(usCandidate?.primaryImprovement ?? 0);
   });
 });

--- a/apps/savings-web/src/lib/allocationAdvisor.spec.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Holding, PortfolioSettings } from '../types';
+import type { PortfolioExposure } from './allocationAdvisor';
 import { computeExposure, distanceToTargets, rankCandidates } from './allocationAdvisor';
 
 const settings: PortfolioSettings = {
@@ -70,6 +71,19 @@ describe('distanceToTargets()', () => {
     const exposure = computeExposure([holding({ id: 'a', currentAmountIls: 100, currencyExposure: 'ils', assetType: 'equity', geography: 'ישראל' })]);
     expect(distanceToTargets(exposure, settings, ['ישראל', 'ארהב'])).toBeGreaterThan(0);
   });
+
+  it('weights the farthest category more heavily than a near one (squared gaps)', () => {
+    // One category 20% off contributes 400; two categories 10% off each contribute only 200 combined.
+    const farOneCategory: PortfolioExposure = { fxPercent: 70, solidPercent: 50, geographyPercent: new Map([['ישראל', 50], ['ארהב', 50]]) };
+    const closeTwoCategories: PortfolioExposure = { fxPercent: 60, solidPercent: 60, geographyPercent: new Map([['ישראל', 50], ['ארהב', 50]]) };
+    expect(distanceToTargets(farOneCategory, settings, ['ישראל', 'ארהב'])).toBeGreaterThan(distanceToTargets(closeTwoCategories, settings, ['ישראל', 'ארהב']));
+  });
+
+  it('uses the single worst region gap for the geography category', () => {
+    const oneRegionFar: PortfolioExposure = { fxPercent: 50, solidPercent: 50, geographyPercent: new Map([['ישראל', 70], ['ארהב', 30]]) };
+    // Worst region gap is 20 → 400; fx and solid contribute nothing.
+    expect(distanceToTargets(oneRegionFar, settings, ['ישראל', 'ארהב'])).toBeCloseTo(400);
+  });
 });
 
 describe('rankCandidates()', () => {
@@ -94,5 +108,27 @@ describe('rankCandidates()', () => {
   it('limits the result to topN candidates', () => {
     const holdings = [holding({ id: 'a' }), holding({ id: 'b' }), holding({ id: 'c' }), holding({ id: 'd' })];
     expect(rankCandidates(holdings, settings, 100, 3)).toHaveLength(3);
+  });
+
+  it('only suggests manual holdings, never managed ones', () => {
+    const holdings = [
+      holding({ id: 'managed-a', account: 'managed', currentAmountIls: 50, currencyExposure: 'fx', assetType: 'equity', geography: 'ארהב' }),
+      holding({ id: 'manual-a', account: 'manual', currentAmountIls: 50, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
+    ];
+    const ranked = rankCandidates(holdings, settings, 100, 3);
+    expect(ranked.every((candidate) => candidate.holding.account === 'manual')).toBe(true);
+    expect(ranked.some((candidate) => candidate.holding.id === 'managed-a')).toBe(false);
+  });
+
+  it('prioritizes the manual holding that closes the farthest category first', () => {
+    // fx is 30% off target (far); geography is only ~7% off (near). The manual holding that fixes
+    // the far fx gap should rank ahead of one that only nudges the already-near geography split.
+    const holdings = [
+      holding({ id: 'ils-anchor', account: 'managed', currentAmountIls: 80, currencyExposure: 'ils', assetType: 'solid', geography: 'ישראל' }),
+      holding({ id: 'fx-fixer', account: 'manual', currentAmountIls: 20, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
+      holding({ id: 'geo-nudger', account: 'manual', currentAmountIls: 20, currencyExposure: 'ils', assetType: 'solid', geography: 'ארהב' }),
+    ];
+    const ranked = rankCandidates(holdings, settings, 60, 3);
+    expect(ranked[0]?.holding.id).toEqual('fx-fixer');
   });
 });

--- a/apps/savings-web/src/lib/allocationAdvisor.spec.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.spec.ts
@@ -131,4 +131,24 @@ describe('rankCandidates()', () => {
     const ranked = rankCandidates(holdings, settings, 60, 3);
     expect(ranked[0]?.holding.id).toEqual('fx-fixer');
   });
+
+  it('does not rank a holding that worsens the dominant category, even if it helps smaller gaps', () => {
+    // Dominant gap is geography ישראל: 60% vs 25% target (gap 35). fx is only 5% off.
+    // 'israel-fx' improves fx but pushes ישראל further over target -> must not rank first.
+    // 'us-fixer' pulls ישראל down toward target -> should rank first.
+    const geoSettings: PortfolioSettings = { ...settings, fxLimitPercent: 65, solidTargetPercent: 0, geographyTargets: { ישראל: 25, ארהב: 25, אסיה: 25, אירופה: 25 } };
+    const holdings = [
+      holding({ id: 'israel-anchor', account: 'managed', currentAmountIls: 60, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
+      holding({ id: 'us-anchor', account: 'managed', currentAmountIls: 20, currencyExposure: 'ils', assetType: 'equity', geography: 'ארהב' }),
+      holding({ id: 'asia-anchor', account: 'managed', currentAmountIls: 20, currencyExposure: 'fx', assetType: 'equity', geography: 'אסיה' }),
+      holding({ id: 'israel-fx', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'equity', geography: 'ישראל' }),
+      holding({ id: 'us-fixer', account: 'manual', currentAmountIls: 0, currencyExposure: 'fx', assetType: 'equity', geography: 'ארהב' }),
+    ];
+    const ranked = rankCandidates(holdings, geoSettings, 40, 3);
+    expect(ranked[0]?.holding.id).toEqual('us-fixer');
+    expect(ranked[0]?.primaryImprovement).toBeGreaterThan(0);
+    // The ישראל holding worsens the dominant geography gap -> negative primary improvement.
+    const israelCandidate = ranked.find((candidate) => candidate.holding.id === 'israel-fx');
+    expect(israelCandidate?.primaryImprovement ?? 0).toBeLessThan(0);
+  });
 });

--- a/apps/savings-web/src/lib/allocationAdvisor.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.ts
@@ -42,8 +42,11 @@ export function distanceToTargets(exposure: PortfolioExposure, settings: Portfol
   const fxGap = Math.abs(exposure.fxPercent - settings.fxLimitPercent);
   const solidGap = Math.abs(exposure.solidPercent - settings.solidTargetPercent);
   const geographyGaps = geographyLabels.map((label) => Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)));
-  const geographyGap = geographyGaps.length > 0 ? sum(geographyGaps) / geographyGaps.length : 0;
-  return fxGap + solidGap + geographyGap;
+  const geographyGap = geographyGaps.length > 0 ? Math.max(...geographyGaps) : 0;
+  // Square each category's gap so the category farthest from its target dominates the score.
+  // This makes a deposit that shrinks the largest gap yield the biggest improvement, instead of
+  // treating a category already near its target the same as one far from it.
+  return fxGap * fxGap + solidGap * solidGap + geographyGap * geographyGap;
 }
 
 function depositedHoldings(holdings: readonly Holding[], holdingId: string, depositAmountIls: number): Holding[] {
@@ -74,7 +77,11 @@ export function rankCandidates(holdings: readonly Holding[], settings: Portfolio
   const beforeExposure = computeExposure(holdings);
   const distanceBefore = distanceToTargets(beforeExposure, settings, GEOGRAPHY_LABELS);
 
+  // Only manual holdings (חלק בתיק = ידני) are under the user's control, so the deposit can only be
+  // suggested there. Managed holdings are excluded as candidates, but the exposure/distance is still
+  // computed over the whole portfolio so the effect on the full portfolio is measured correctly.
   return holdings
+    .filter((holding) => holding.account === 'manual')
     .map((holding) => {
       const afterExposure = computeExposure(depositedHoldings(holdings, holding.id, depositAmountIls));
       const distanceAfter = distanceToTargets(afterExposure, settings, GEOGRAPHY_LABELS);

--- a/apps/savings-web/src/lib/allocationAdvisor.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.ts
@@ -12,6 +12,7 @@ export type PortfolioExposure = {
 export type AdvisorCandidate = {
   readonly holding: Holding;
   readonly improvement: number;
+  readonly primaryImprovement: number;
   readonly distanceBefore: number;
   readonly distanceAfter: number;
   readonly explanation: string;
@@ -49,19 +50,44 @@ export function distanceToTargets(exposure: PortfolioExposure, settings: Portfol
   return fxGap * fxGap + solidGap * solidGap + geographyGap * geographyGap;
 }
 
+type CategoryGap = { readonly key: string; readonly gap: number };
+
+// The individual per-category gaps (in percentage points), geography split into one entry per region.
+// Used to identify the single category that is currently farthest from its target so the ranking can
+// prioritize closing it, rather than optimizing only the net sum (which a holding can "game" by
+// helping several small gaps while worsening the dominant one).
+function categoryGaps(exposure: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[]): CategoryGap[] {
+  return [
+    { key: 'fx', gap: Math.abs(exposure.fxPercent - settings.fxLimitPercent) },
+    { key: 'solid', gap: Math.abs(exposure.solidPercent - settings.solidTargetPercent) },
+    ...geographyLabels.map((label) => ({ key: `geo:${label}`, gap: Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)) })),
+  ];
+}
+
+function gapForCategory(exposure: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[], key: string): number {
+  return categoryGaps(exposure, settings, geographyLabels).find((entry) => entry.key === key)?.gap ?? 0;
+}
+
 function depositedHoldings(holdings: readonly Holding[], holdingId: string, depositAmountIls: number): Holding[] {
   return holdings.map((holding) => (holding.id === holdingId ? { ...holding, currentAmountIls: nonNegative(holding.currentAmountIls) + depositAmountIls } : holding));
 }
 
-function explainCandidate(before: PortfolioExposure, after: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[]): string {
-  const movers: { readonly label: string; readonly reduction: number }[] = [
-    { label: 'חשיפת המט״ח', reduction: Math.abs(before.fxPercent - settings.fxLimitPercent) - Math.abs(after.fxPercent - settings.fxLimitPercent) },
-    { label: 'איזון סולידי-מנייתי', reduction: Math.abs(before.solidPercent - settings.solidTargetPercent) - Math.abs(after.solidPercent - settings.solidTargetPercent) },
+function explainCandidate(before: PortfolioExposure, after: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[], primaryKey?: string): string {
+  const movers: { readonly key: string; readonly label: string; readonly reduction: number }[] = [
+    { key: 'fx', label: 'חשיפת המט״ח', reduction: Math.abs(before.fxPercent - settings.fxLimitPercent) - Math.abs(after.fxPercent - settings.fxLimitPercent) },
+    { key: 'solid', label: 'איזון סולידי-מנייתי', reduction: Math.abs(before.solidPercent - settings.solidTargetPercent) - Math.abs(after.solidPercent - settings.solidTargetPercent) },
     ...geographyLabels.map((label) => ({
+      key: `geo:${label}`,
       label: `אזור ${label}`,
       reduction: Math.abs((before.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)) - Math.abs((after.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)),
     })),
   ];
+
+  // Warn when the deposit pushes the farthest category further from its target, so a candidate that
+  // only helps smaller gaps isn't presented as if it fixed the dominant problem.
+  const primaryMover = primaryKey ? movers.find((mover) => mover.key === primaryKey) : undefined;
+  if (primaryMover && primaryMover.reduction < -0.05) return `שימו לב: מרחיקה מהיעד את ${primaryMover.label} (המרכיב הרחוק ביותר כרגע).`;
+
   const topMovers = movers
     .filter((mover) => mover.reduction > 0.05)
     .sort((first, second) => second.reduction - first.reduction)
@@ -77,6 +103,11 @@ export function rankCandidates(holdings: readonly Holding[], settings: Portfolio
   const beforeExposure = computeExposure(holdings);
   const distanceBefore = distanceToTargets(beforeExposure, settings, GEOGRAPHY_LABELS);
 
+  // The single category currently farthest from its target. The ranking prioritizes shrinking this
+  // gap so a deposit can't win merely by nudging several small gaps while worsening the dominant one.
+  const farthest = categoryGaps(beforeExposure, settings, GEOGRAPHY_LABELS).sort((first, second) => second.gap - first.gap)[0];
+  const primaryGapBefore = farthest?.gap ?? 0;
+
   // Only manual holdings (חלק בתיק = ידני) are under the user's control, so the deposit can only be
   // suggested there. Managed holdings are excluded as candidates, but the exposure/distance is still
   // computed over the whole portfolio so the effect on the full portfolio is measured correctly.
@@ -85,14 +116,18 @@ export function rankCandidates(holdings: readonly Holding[], settings: Portfolio
     .map((holding) => {
       const afterExposure = computeExposure(depositedHoldings(holdings, holding.id, depositAmountIls));
       const distanceAfter = distanceToTargets(afterExposure, settings, GEOGRAPHY_LABELS);
+      const primaryGapAfter = farthest ? gapForCategory(afterExposure, settings, GEOGRAPHY_LABELS, farthest.key) : 0;
       return {
         holding,
         improvement: distanceBefore - distanceAfter,
+        primaryImprovement: primaryGapBefore - primaryGapAfter,
         distanceBefore,
         distanceAfter,
-        explanation: explainCandidate(beforeExposure, afterExposure, settings, GEOGRAPHY_LABELS),
+        explanation: explainCandidate(beforeExposure, afterExposure, settings, GEOGRAPHY_LABELS, farthest?.key),
       };
     })
-    .sort((first, second) => second.improvement - first.improvement)
+    // Primary: how much the deposit closes the farthest category's gap. Secondary: total distance
+    // improvement, used as a tiebreaker when the primary effect is effectively equal.
+    .sort((first, second) => (Math.abs(second.primaryImprovement - first.primaryImprovement) > 0.01 ? second.primaryImprovement - first.primaryImprovement : second.improvement - first.improvement))
     .slice(0, topN);
 }

--- a/apps/savings-web/src/lib/allocationAdvisor.ts
+++ b/apps/savings-web/src/lib/allocationAdvisor.ts
@@ -42,8 +42,11 @@ export function computeExposure(holdings: readonly Holding[]): PortfolioExposure
 export function distanceToTargets(exposure: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[]): number {
   const fxGap = Math.abs(exposure.fxPercent - settings.fxLimitPercent);
   const solidGap = Math.abs(exposure.solidPercent - settings.solidTargetPercent);
-  const geographyGaps = geographyLabels.map((label) => Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)));
-  const geographyGap = geographyGaps.length > 0 ? Math.max(...geographyGaps) : 0;
+  // Sum every region's gap so the geography category captures the whole allocation, not just its
+  // single worst region. This lets the score tell an over-target region apart from an under-target
+  // one: depositing into a region that is already over target grows its gap and is penalized, while
+  // depositing into an under-target region shrinks two fronts at once.
+  const geographyGap = sum(geographyLabels.map((label) => Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0))));
   // Square each category's gap so the category farthest from its target dominates the score.
   // This makes a deposit that shrinks the largest gap yield the biggest improvement, instead of
   // treating a category already near its target the same as one far from it.
@@ -52,15 +55,17 @@ export function distanceToTargets(exposure: PortfolioExposure, settings: Portfol
 
 type CategoryGap = { readonly key: string; readonly gap: number };
 
-// The individual per-category gaps (in percentage points), geography split into one entry per region.
-// Used to identify the single category that is currently farthest from its target so the ranking can
-// prioritize closing it, rather than optimizing only the net sum (which a holding can "game" by
-// helping several small gaps while worsening the dominant one).
+// The individual per-category gaps (in percentage points). Geography is a single aggregate entry
+// (the sum of every region's gap) so the category matches the score in distanceToTargets and can
+// distinguish an over-target region from an under-target one. Used to identify the single category
+// currently farthest from its target so the ranking can prioritize closing it, rather than
+// optimizing only the net sum (which a holding can "game" by helping several small gaps while
+// worsening the dominant one).
 function categoryGaps(exposure: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[]): CategoryGap[] {
   return [
     { key: 'fx', gap: Math.abs(exposure.fxPercent - settings.fxLimitPercent) },
     { key: 'solid', gap: Math.abs(exposure.solidPercent - settings.solidTargetPercent) },
-    ...geographyLabels.map((label) => ({ key: `geo:${label}`, gap: Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)) })),
+    { key: 'geo', gap: sum(geographyLabels.map((label) => Math.abs((exposure.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)))) },
   ];
 }
 
@@ -73,22 +78,22 @@ function depositedHoldings(holdings: readonly Holding[], holdingId: string, depo
 }
 
 function explainCandidate(before: PortfolioExposure, after: PortfolioExposure, settings: PortfolioSettings, geographyLabels: readonly string[], primaryKey?: string): string {
-  const movers: { readonly key: string; readonly label: string; readonly reduction: number }[] = [
-    { key: 'fx', label: 'חשיפת המט״ח', reduction: Math.abs(before.fxPercent - settings.fxLimitPercent) - Math.abs(after.fxPercent - settings.fxLimitPercent) },
-    { key: 'solid', label: 'איזון סולידי-מנייתי', reduction: Math.abs(before.solidPercent - settings.solidTargetPercent) - Math.abs(after.solidPercent - settings.solidTargetPercent) },
-    ...geographyLabels.map((label) => ({
-      key: `geo:${label}`,
-      label: `אזור ${label}`,
-      reduction: Math.abs((before.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)) - Math.abs((after.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)),
-    })),
-  ];
+  const geoReduction = (label: string): number =>
+    Math.abs((before.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0)) - Math.abs((after.geographyPercent.get(label) ?? 0) - (settings.geographyTargets[label] ?? 0));
+
+  const fxMover = { key: 'fx', label: 'חשיפת המט״ח', reduction: Math.abs(before.fxPercent - settings.fxLimitPercent) - Math.abs(after.fxPercent - settings.fxLimitPercent) };
+  const solidMover = { key: 'solid', label: 'איזון סולידי-מנייתי', reduction: Math.abs(before.solidPercent - settings.solidTargetPercent) - Math.abs(after.solidPercent - settings.solidTargetPercent) };
+  // Aggregate geography mover (whole category) for the warning, plus per-region movers for the
+  // positive message so it can name the specific region(s) the deposit helped.
+  const geoMover = { key: 'geo', label: 'החלוקה לפי אזור', reduction: sum(geographyLabels.map(geoReduction)) };
+  const regionMovers = geographyLabels.map((label) => ({ key: `geo:${label}`, label: `אזור ${label}`, reduction: geoReduction(label) }));
 
   // Warn when the deposit pushes the farthest category further from its target, so a candidate that
   // only helps smaller gaps isn't presented as if it fixed the dominant problem.
-  const primaryMover = primaryKey ? movers.find((mover) => mover.key === primaryKey) : undefined;
+  const primaryMover = primaryKey ? [fxMover, solidMover, geoMover].find((mover) => mover.key === primaryKey) : undefined;
   if (primaryMover && primaryMover.reduction < -0.05) return `שימו לב: מרחיקה מהיעד את ${primaryMover.label} (המרכיב הרחוק ביותר כרגע).`;
 
-  const topMovers = movers
+  const topMovers = [fxMover, solidMover, ...regionMovers]
     .filter((mover) => mover.reduction > 0.05)
     .sort((first, second) => second.reduction - first.reduction)
     .slice(0, 2)


### PR DESCRIPTION
## What

Improves the savings app's "יעוץ הפקדה" (deposit advisor) suggestion feature in two ways:

1. **Manual-only candidates** — Suggestions are now offered only for holdings whose חלק בתיק is `ידני` (`account === 'manual'`), since those are the ones the user actually controls. Managed holdings are excluded as candidates. The exposure/distance is still computed over the **whole portfolio**, so the effect of a deposit on the full portfolio is measured correctly.

2. **Prioritize the farthest category** — Ranking previously summed the linear gaps of the three categories (fx / solid-equity / geography), so a category already close to its target counted the same as one far off. Now each category's gap is **squared**, so the category farthest from its target dominates the score and gets addressed first. Geography (which has multiple regions) uses its **single worst region gap** as the category distance.

## Changes

- `apps/savings-web/src/lib/allocationAdvisor.ts` — squared-gap distance metric (worst-region for geography) + manual-only candidate filter.
- `apps/savings-web/src/components/DepositAdvisorModal.tsx` — empty-state copy clarifies suggestions apply only to `ידני` holdings.
- `apps/savings-web/src/lib/allocationAdvisor.spec.ts` — new tests for weighted/worst-region distance, manual-only filtering, and farthest-category-first ranking.

## Validation

- Unit tests: all savings-web tests pass (39/39).
- `npm run build --workspace apps/savings-web` succeeds.
- ESLint clean on changed files.
- Verified live in the dev server with a mocked portfolio: only the two `ידני` holdings appear as candidates (managed excluded), and the fx/equity holding that closes the far fx & solid gaps ranks #1 over the holding that only nudges the already-near geography split.
