### PR TITLE
refactor(chatbot): trim scheduler and exercise messages

### DIFF
--- a/src/features/chatbot/agent/agent.ts
+++ b/src/features/chatbot/agent/agent.ts
@@ -190,9 +190,7 @@ Smart Reminders Guidelines:
 Exercise Tracking Guidelines:
 - When I mention exercising, working out, or completing fitness activities, use the exercise_tracker tool to log my exercise.
 - Natural language variations to recognize: "I exercised", "just worked out", "finished my training", "completed my workout", "did my exercise", etc.
-- After logging an exercise, always check if I broke my streak record using the exercise_analytics tool with action "check_record".
-- If a new record is broken, celebrate with the generated image and enthusiastic message.
-- Show exercise stats after logging: current streak, this week's progress, and total exercises.
+- After logging an exercise, reply with a short, encouraging confirmation. Do NOT mention my current streak or the total number of exercises I've done all time.
 - For achievement requests ("show my achievements", "my fitness stats"), use exercise_tracker with get_streaks action and format nicely with emojis.
 - Use motivational language and emojis (💪🔥🏋️‍♂️🚀💯) to encourage me.
 

--- a/src/features/chatbot/schedulers/daily-summary.ts
+++ b/src/features/chatbot/schedulers/daily-summary.ts
@@ -26,7 +26,6 @@ Show 4 different times throughout the day (morning, noon, afternoon, and evening
 2. **Birthday Reminders**: Check if any of tomorrow's calendar events are birthdays (events with "birthday" in the title). For each birthday you find:
    - Extract the person's name from the event title
    - If there are birthdays tomorrows, dont add the birthday section.
-3. **Exercises**: Mention if I exercised today or not. Keep it brief (1-2 sentences max).
 
 Please format the response nicely with emojis and make it feel like a friendly good night message. Start with a short warm greeting like "🌙 Good night!" and end with a message encouraging me to prepare for tomorrow's challenges.`;
 

--- a/src/features/chatbot/schedulers/exercise-reminder.ts
+++ b/src/features/chatbot/schedulers/exercise-reminder.ts
@@ -16,6 +16,7 @@ export async function exerciseReminder(bot: Bot, chatbotService: ChatbotService)
     const prompt = `Generate a motivational exercise reminder for me. I haven't exercised today yet.
     Use the exercise_analytics tool with action "generate_reminder" to get a motivational meme if available.
     Keep the message short, fun, and encouraging. Use emojis to make it engaging.
+    Do NOT mention my current streak or the total number of exercises I've done all time.
     If a meme URL is available, send it along with a short motivational message.`;
 
     const response = await chatbotService.processMessage(prompt, MY_USER_ID);

--- a/src/features/chatbot/schedulers/sports-calendar.ts
+++ b/src/features/chatbot/schedulers/sports-calendar.ts
@@ -80,7 +80,7 @@ export async function sportsCalendar(bot: Bot, chatbotService: ChatbotService): 
    - location: The venue from the match data
 
 6. After creating calendar events, send me a summary message in English:
-   - If events were created: "✅ Added [X] matches to the calendar:" followed by the list grouped by day with brief explanation why each was added
+   - If events were created: "✅ Added [X] matches to the calendar:" followed by the list of game names only (e.g., "⚽ [Home Team] vs [Away Team]"). Do NOT include any explanation of why each match was added.
    - If no matches found: "No matches coming up for my favorite teams, the World Cup, or other important fixtures 🤷‍♂️"`;
 
     const response = await chatbotService.processMessage(prompt, MY_USER_ID);

--- a/src/features/chatbot/schedulers/upcoming-event-alert.ts
+++ b/src/features/chatbot/schedulers/upcoming-event-alert.ts
@@ -5,6 +5,7 @@ import { CalendarEvent, listEvents } from '@services/google-calendar';
 
 const logger = new Logger('UpcomingEventAlertScheduler');
 
+export const LEAD_MINUTES = 15;
 export const WINDOW_MINUTES = 15;
 const GRACE_MS = 60 * 1000;
 
@@ -14,7 +15,7 @@ function buildMessage(event: CalendarEvent): string {
   const title = event.summary || 'Untitled Event';
   const startStr = formatTime(event.start.dateTime!);
   const endStr = event.end?.dateTime ? ` - ${formatTime(event.end.dateTime)}` : '';
-  const lines = [`📅 *Upcoming event*`, ``, `*${title}*`, `🕒 ${startStr}${endStr}`];
+  const lines = [`📅 *Upcoming event* (in ~${LEAD_MINUTES} min)`, ``, `*${title}*`, `🕒 ${startStr}${endStr}`];
   if (event.location) lines.push(`📍 ${event.location}`);
   if (event.description) lines.push(``, event.description);
   return lines.join('\n');
@@ -23,15 +24,16 @@ function buildMessage(event: CalendarEvent): string {
 export async function upcomingEventAlert(bot: Bot): Promise<void> {
   try {
     const now = new Date();
-    const windowEnd = new Date(now.getTime() + WINDOW_MINUTES * 60 * 1000);
+    const windowStart = new Date(now.getTime() + LEAD_MINUTES * 60 * 1000);
+    const windowEnd = new Date(windowStart.getTime() + WINDOW_MINUTES * 60 * 1000);
 
-    const events = await listEvents({ timeMin: now.toISOString(), timeMax: windowEnd.toISOString(), singleEvents: true, orderBy: 'startTime' });
+    const events = await listEvents({ timeMin: windowStart.toISOString(), timeMax: windowEnd.toISOString(), singleEvents: true, orderBy: 'startTime' });
 
     const upcoming = (events || []).filter((event) => {
       if (!event.start?.dateTime) return false;
       if (event.status === 'cancelled') return false;
       const startTime = new Date(event.start.dateTime).getTime();
-      return startTime >= now.getTime() - GRACE_MS && startTime <= windowEnd.getTime();
+      return startTime >= windowStart.getTime() - GRACE_MS && startTime <= windowEnd.getTime();
     });
 
     if (!upcoming.length) {

--- a/src/features/chatbot/schedulers/usage-summary.ts
+++ b/src/features/chatbot/schedulers/usage-summary.ts
@@ -10,19 +10,24 @@ import type { UsageAggregateRow } from '@shared/ai';
 const logger = new Logger('UsageSummaryScheduler');
 
 const LOOKBACK_DAYS = 7;
+const PREVIOUS_WEEKS = 3;
 
 export async function usageSummary(bot: Bot): Promise<void> {
   try {
     const to = new Date();
     const from = subDays(to, LOOKBACK_DAYS);
-    const rows = await aggregateUsage({ from, to });
+    const comparisonFrom = subDays(to, LOOKBACK_DAYS * (PREVIOUS_WEEKS + 1));
+    const rows = await aggregateUsage({ from: comparisonFrom, to });
 
-    if (!rows.length) {
+    const weekStartDay = dayKey(from);
+    const thisWeekRows = rows.filter((row) => row.day >= weekStartDay);
+
+    if (!thisWeekRows.length) {
       await bot.api.sendMessage(MY_USER_ID, '💰 No AI usage recorded in the past week.');
       return;
     }
 
-    const message = buildUsageSummaryMessage(rows, from, to);
+    const message = buildUsageSummaryMessage(rows, thisWeekRows, weekStartDay, from, to);
     await sendShortenedMessage(bot, MY_USER_ID, message, { parse_mode: 'Markdown' });
   } catch (err) {
     logger.error(`Failed to send weekly usage summary: ${err}`);
@@ -32,13 +37,16 @@ export async function usageSummary(bot: Bot): Promise<void> {
 
 type Totals = { turns: number; tokens: number; cost: number };
 
-function buildUsageSummaryMessage(rows: UsageAggregateRow[], from: Date, to: Date): string {
-  const totalTurns = rows.reduce((sum, row) => sum + row.turns, 0);
-  const totalTokens = rows.reduce((sum, row) => sum + row.tokensTotal, 0);
-  const totalCost = rows.reduce((sum, row) => sum + row.cost, 0);
+function dayKey(date: Date): string {
+  return format(toZonedTime(date, DEFAULT_TIMEZONE), 'yyyy-MM-dd');
+}
 
-  const perSource = aggregateBy(rows, (row) => row.source);
-  const perDay = aggregateBy(rows, (row) => row.day);
+function buildUsageSummaryMessage(allRows: UsageAggregateRow[], thisWeekRows: UsageAggregateRow[], weekStartDay: string, from: Date, to: Date): string {
+  const totalTurns = thisWeekRows.reduce((sum, row) => sum + row.turns, 0);
+  const totalTokens = thisWeekRows.reduce((sum, row) => sum + row.tokensTotal, 0);
+  const totalCost = thisWeekRows.reduce((sum, row) => sum + row.cost, 0);
+
+  const perSource = aggregateBy(thisWeekRows, (row) => row.source);
 
   const fromLabel = format(toZonedTime(from, DEFAULT_TIMEZONE), 'MMM d');
   const toLabel = format(toZonedTime(to, DEFAULT_TIMEZONE), 'MMM d');
@@ -58,13 +66,41 @@ function buildUsageSummaryMessage(rows: UsageAggregateRow[], from: Date, to: Dat
   }
 
   lines.push('');
-  lines.push('*By day:*');
-  const days = [...perDay.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-  for (const [day, entry] of days) {
-    lines.push(`• ${day}: $${entry.cost.toFixed(4)} · ${entry.turns} turns`);
+  lines.push(`*This week vs previous ${PREVIOUS_WEEKS}-week avg (by bot):*`);
+  const previousRows = allRows.filter((row) => row.day < weekStartDay);
+  const previousCostBySource = costBySource(previousRows);
+  const thisWeekCostBySource = costBySource(thisWeekRows);
+  const allSources = new Set<string>([...thisWeekCostBySource.keys(), ...previousCostBySource.keys()]);
+  const comparison = [...allSources]
+    .map((source) => {
+      const thisWeekCost = thisWeekCostBySource.get(source) ?? 0;
+      const prevAvgCost = (previousCostBySource.get(source) ?? 0) / PREVIOUS_WEEKS;
+      return { source, thisWeekCost, prevAvgCost };
+    })
+    .sort((a, b) => b.thisWeekCost - a.thisWeekCost);
+  for (const { source, thisWeekCost, prevAvgCost } of comparison) {
+    lines.push(`• ${source}: $${thisWeekCost.toFixed(4)} vs $${prevAvgCost.toFixed(4)} avg ${formatDelta(thisWeekCost, prevAvgCost)}`);
   }
 
   return lines.join('\n');
+}
+
+function formatDelta(current: number, baseline: number): string {
+  const diff = current - baseline;
+  const arrow = diff > 0 ? '🔺' : diff < 0 ? '🔻' : '➖';
+  if (baseline === 0) {
+    return current === 0 ? '(➖ no change)' : '(🔺 new)';
+  }
+  const pct = (diff / baseline) * 100;
+  return `(${arrow} ${pct >= 0 ? '+' : ''}${pct.toFixed(0)}%)`;
+}
+
+function costBySource(rows: UsageAggregateRow[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    map.set(row.source, (map.get(row.source) ?? 0) + row.cost);
+  }
+  return map;
 }
 
 function aggregateBy(rows: UsageAggregateRow[], keyFn: (row: UsageAggregateRow) => string): Map<string, Totals> {


### PR DESCRIPTION
Tidies up several chatbot notification messages so they say only what's useful and adjusts the calendar alert timing.

## Why
The daily/exercise/sports/usage messages had grown noisy (streak call-outs, all-time counts, per-match justifications, per-day usage rows), and the upcoming-event alert fired right as the event started instead of giving a heads-up.

## Changes
- **Daily summary (11 PM):** removed the "did I exercise today" section.
- **Exercise messages:** the after-logging confirmation (agent prompt) and the 7 PM reminder no longer mention the current streak or the all-time exercise count. The 7 PM reminder itself is otherwise unchanged.
- **Sports calendar (twice weekly):** the summary now lists only the added game names, without the per-match "why it was added" explanation. Selection logic is untouched.
- **Weekly usage summary (Saturday):** dropped the per-day turns/cost breakdown. Added a "this week vs previous 3-week average" per-bot cost comparison (fetches 4 weeks, shows this week's cost against the prior 3-week average with a percentage delta).
- **Upcoming event alert:** now fires ~15 minutes before an event (window shifted forward by a 15-minute lead) instead of at the moment it starts. Message header updated to reflect the lead time.

## Notes for reviewers
- Most edits are prompt/string changes. The usage-summary change is the only real logic change: day bucketing relies on lexicographic YYYY-MM-DD comparison, and the empty-state now triggers only when the current week has no usage.
- TypeScript is not installed in this worktree, so tsc was not run. Changes are type-consistent with existing types (UsageAggregateRow, CalendarEvent).
