### PR TITLE
feat(chatbot): link telegram digest posts and shorten long ones

### DIFF
--- a/src/features/chatbot/chatbot-scheduler.service.ts
+++ b/src/features/chatbot/chatbot-scheduler.service.ts
@@ -66,7 +66,7 @@ export class ChatbotSchedulerService {
 
     createSchedule(`30 18 * * *`, async () => socialMediaCollect(['tiktok']));
 
-    createSchedule(`30 11-23 * * *`, async () => socialMediaCollect(['telegram']));
+    createSchedule(`30 * * * *`, async () => socialMediaCollect(['telegram']));
 
     createSchedule(`45 22 * * *`, async () => socialMediaDigest(this.bot));
 

--- a/src/features/chatbot/schedulers/social-media-digest.spec.ts
+++ b/src/features/chatbot/schedulers/social-media-digest.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { targetKeyPointsCount } from './social-media-digest';
+import { isLongPost, targetKeyPointsCount } from './social-media-digest';
 
 describe('targetKeyPointsCount()', () => {
   test.each([
@@ -12,5 +12,17 @@ describe('targetKeyPointsCount()', () => {
     { postsCount: 500, expected: 10 },
   ])('should return $expected when postsCount is $postsCount', ({ postsCount, expected }) => {
     expect(targetKeyPointsCount(postsCount)).toEqual(expected);
+  });
+});
+
+describe('isLongPost()', () => {
+  test.each([
+    { label: 'null', text: null, expected: false },
+    { label: 'empty', text: '', expected: false },
+    { label: 'short text', text: 'a'.repeat(100), expected: false },
+    { label: 'exactly at threshold (280)', text: 'a'.repeat(280), expected: false },
+    { label: 'over threshold (281)', text: 'a'.repeat(281), expected: true },
+  ])('should return $expected for $label', ({ text, expected }) => {
+    expect(isLongPost(text)).toEqual(expected);
   });
 });

--- a/src/features/chatbot/schedulers/social-media-digest.ts
+++ b/src/features/chatbot/schedulers/social-media-digest.ts
@@ -11,11 +11,16 @@ import type { PendingPost, SocialPlatform } from '@shared/social-follower';
 const logger = new Logger('SocialMediaDigestScheduler');
 
 const PLATFORM_LABELS = { tiktok: 'TikTok 🎵', twitter: 'X (Twitter) 🐦', youtube: 'YouTube 📺', telegram: 'Telegram 📣' } as const;
-const SUMMARIZED_PLATFORMS: SocialPlatform[] = ['telegram', 'twitter']; // chatty platforms get AI summaries; the rest list each post
+const SUMMARIZED_PLATFORMS: SocialPlatform[] = ['twitter']; // chatty platforms get AI topic summaries; the rest list each post
 const MAX_FALLBACK_POSTS = 15; // raw listing cap when summarization fails
+const LONG_POST_THRESHOLD = 280; // posts longer than this are AI-shortened in per-post listings
 
 const summarySchema = z.object({
   keyPoints: z.array(z.string()).describe('The key points of what the author posted about, one bullet per distinct topic'),
+});
+
+const shortenSchema = z.object({
+  shortened: z.array(z.string()).describe('The shortened posts, one per input post, in the same order as the input'),
 });
 
 // Sends the daily digest of everything the collectors stored since the last digest,
@@ -56,6 +61,9 @@ async function processDigestForChat(bot: Bot, chatId: number, posts: PendingPost
 }
 
 async function buildUserSection(userPosts: PendingPost[]): Promise<string> {
+  if (userPosts[0].platform === 'telegram') {
+    return buildTelegramListingSection(userPosts);
+  }
   if (!SUMMARIZED_PLATFORMS.includes(userPosts[0].platform)) {
     return buildListingSection(userPosts);
   }
@@ -77,6 +85,53 @@ function buildListingSection(userPosts: PendingPost[], maxPosts?: number): strin
   const omitted = userPosts.length - shown.length;
   const omittedNote = omitted > 0 ? `\n- ...and ${omitted} more` : '';
   return `${sectionHeader(userPosts)}\n${lines.join('\n')}${omittedNote}`;
+}
+
+export function isLongPost(text: string | null): boolean {
+  return !!text && text.length > LONG_POST_THRESHOLD;
+}
+
+function telegramPostLine(text: string, url: string | null): string {
+  const clean = text.replace(/\s+/g, ' ').trim() || '(no caption)';
+  return url ? `- ${clean} — [link](${url})` : `- ${clean}`;
+}
+
+// Renders one line per Telegram post (newest first) with a direct message link.
+// Posts longer than LONG_POST_THRESHOLD are AI-shortened in a single batched call.
+async function buildTelegramListingSection(userPosts: PendingPost[]): Promise<string> {
+  const displayTexts = await shortenLongPosts(userPosts.map((post) => post.text));
+  const lines = userPosts.map((post, i) => telegramPostLine(displayTexts[i], post.url));
+  return `${sectionHeader(userPosts)}\n${lines.join('\n')}`;
+}
+
+// Returns display text per post, shortening only posts over the threshold. All long
+// posts are shortened in one AI call (index-aligned); on failure they hard-truncate.
+async function shortenLongPosts(texts: (string | null)[]): Promise<string[]> {
+  const longIndexes = texts.map((text, i) => (isLongPost(text) ? i : -1)).filter((i) => i !== -1);
+  if (!longIndexes.length) {
+    return texts.map((text) => text ?? '');
+  }
+
+  const longTexts = longIndexes.map((i) => texts[i]);
+  const instructions = [
+    `You shorten social media posts so a daily digest stays scannable.`,
+    `You will receive ${longTexts.length} long posts. Return exactly ${longTexts.length} shortened versions, in the same order.`,
+    `Each shortened version is 1-2 short sentences capturing the main point. Do not add opinions or information not in the post.`,
+    `Write each shortened version in the same language the post is written in.`,
+  ].join('\n');
+  const input = longTexts.map((text, i) => `Post ${i + 1}:\n${text}`).join('\n\n');
+
+  try {
+    const { result } = await getResponse({ instructions, input, schema: shortenSchema, model: GPT_SMALL_MODEL, store: false });
+    if (result.shortened.length !== longTexts.length) {
+      throw new Error(`expected ${longTexts.length} shortened posts, got ${result.shortened.length}`);
+    }
+    const shortenedByIndex = new Map(longIndexes.map((originalIndex, k) => [originalIndex, result.shortened[k]]));
+    return texts.map((text, i) => shortenedByIndex.get(i) ?? text ?? '');
+  } catch (err) {
+    logger.error(`Failed to shorten long Telegram posts, falling back to truncation: ${err.message}`);
+    return texts.map((text) => (isLongPost(text) ? `${text.slice(0, LONG_POST_THRESHOLD)}…` : (text ?? '')));
+  }
 }
 
 async function buildSummarySection(userPosts: PendingPost[]): Promise<string> {


### PR DESCRIPTION
## Why

The daily social media digest collapsed a whole day of Telegram posts into merged AI topic-bullets with no way to jump to the original message, and a single very long post could flood the digest with a wall of text. Overnight posts also risked being dropped because collection paused between 23:30 and 11:30, and each fetch only ever sees the last ~20 posts from the public t.me web preview.

## What changed

- **Hourly Telegram collection.** The silent collector cron moves from `30 11-23 * * *` to `30 * * * *`, closing the ~12 hour overnight gap so busy channels don't overflow the 20-post page before the next run.
- **Per-post listing with links.** Telegram now renders one line per post (newest first), each ending in a tappable `[link](https://t.me/<handle>/<id>)`, instead of going through the AI topic-bullet path. Twitter keeps the existing topic-bullet behavior.
- **Shorten only long posts.** Posts over 280 characters are AI-shortened to 1-2 sentences so the digest stays scannable; shorter posts pass through verbatim. All long posts in a section are shortened in a single batched `getResponse` call (index-aligned, original language preserved). If the AI call fails or returns the wrong count, long posts fall back to a hard truncation so the digest still sends.

## Notes for reviewers

- The 280 char threshold is a judgment call (roughly a tweet / a few phone lines); it lives in `LONG_POST_THRESHOLD` and is easy to tune.
- Summarization goes through the raw `@services/openai` helper, so it stays consistent with the rest of the digest and is intentionally not usage-metered.
- Added `isLongPost()` boundary tests (null/empty/short/exactly-280/281) alongside the existing `targetKeyPointsCount` tests.

## Validation

- `npm ci` in this worktree, then `vitest run` on the digest spec: 12 passed.
- `tsc --noEmit`: clean, no type errors.
