### PR TITLE
feat(telemetry): add opt-in OTEL_DEBUG diagnostic logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@octokit/app": "^16.1.2",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^22.0.1",
+        "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.79.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@octokit/app": "^16.1.2",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.79.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",

--- a/src/core/telemetry/otel.ts
+++ b/src/core/telemetry/otel.ts
@@ -1,3 +1,4 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -12,6 +13,10 @@ let sdk: NodeSDK | null = null;
 export function startTelemetry(): void {
   if (sdk) return;
   if (!env.OTEL_EXPORTER_OTLP_ENDPOINT) return; // not configured — stay silent (local dev / no observability)
+
+  if (env.OTEL_DEBUG === 'true') {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG); // surfaces OTLP export attempts/errors in logs
+  }
 
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: env.OTEL_SERVICE_NAME || 'mmps',


### PR DESCRIPTION
## Why

After wiring up Grafana Cloud (#505), traces are not showing up in Application Observability even though a direct `curl` to the OTLP gateway returns `200 OK`. That confirms auth/endpoint are correct, so the issue is app-side and currently invisible because OpenTelemetry fails silently by default.

## What

Adds an opt-in diagnostic switch: set `OTEL_DEBUG=true` and OpenTelemetry logs every export attempt and error to stdout (which is already shipped to Heroku logs). This turns a silent OTLP failure into a visible one so we can pinpoint whether the SDK is exporting, being throttled, or erroring on auth.

Also pins `@opentelemetry/api` as a direct dependency since it is now imported directly (it was previously only transitive).

## How to use

1. Merge and deploy.
2. `heroku config:set OTEL_DEBUG=true -a mmps`
3. `heroku logs --tail -a mmps` while generating a request, and read the OTel diag output.
4. Once diagnosed, remove the var: `heroku config:unset OTEL_DEBUG -a mmps`.

Guarded so it does nothing unless `OTEL_DEBUG=true`; no behavior change otherwise.
