### PR TITLE
fix(telemetry): build otlp auth header in code instead of env parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,9 @@ WEBHOOK_PROXY_URL=
 # Values come from your Grafana Cloud "OpenTelemetry" connection page (see below).
 OTEL_SERVICE_NAME=mmps
 OTEL_EXPORTER_OTLP_ENDPOINT=
-# Format: Authorization=Basic <base64(instanceID:token)>
-OTEL_EXPORTER_OTLP_HEADERS=
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# Auth header is built in code from these two (base64(instanceID:token)):
+GRAFANA_OTLP_INSTANCE_ID=
+GRAFANA_OTLP_TOKEN=
+# Set OTEL_DEBUG=true to log OTLP export attempts/errors while troubleshooting.
+OTEL_DEBUG=

--- a/src/core/telemetry/otel.ts
+++ b/src/core/telemetry/otel.ts
@@ -10,6 +10,13 @@ import { env } from 'node:process';
 
 let sdk: NodeSDK | null = null;
 
+function buildAuthHeaders(): Record<string, string> | undefined {
+  const { GRAFANA_OTLP_INSTANCE_ID, GRAFANA_OTLP_TOKEN } = env;
+  if (!GRAFANA_OTLP_INSTANCE_ID || !GRAFANA_OTLP_TOKEN) return undefined;
+  const credentials = Buffer.from(`${GRAFANA_OTLP_INSTANCE_ID}:${GRAFANA_OTLP_TOKEN}`).toString('base64');
+  return { Authorization: `Basic ${credentials}` }; // built in code to avoid fragile OTEL_EXPORTER_OTLP_HEADERS parsing
+}
+
 export function startTelemetry(): void {
   if (sdk) return;
   if (!env.OTEL_EXPORTER_OTLP_ENDPOINT) return; // not configured — stay silent (local dev / no observability)
@@ -18,6 +25,8 @@ export function startTelemetry(): void {
     diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG); // surfaces OTLP export attempts/errors in logs
   }
 
+  const headers = buildAuthHeaders();
+
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: env.OTEL_SERVICE_NAME || 'mmps',
     [ATTR_SERVICE_VERSION]: env.npm_package_version || '1.0.0',
@@ -25,9 +34,9 @@ export function startTelemetry(): void {
 
   sdk = new NodeSDK({
     resource,
-    traceExporter: new OTLPTraceExporter(),
+    traceExporter: new OTLPTraceExporter({ headers }),
     metricReader: new PeriodicExportingMetricReader({
-      exporter: new OTLPMetricExporter(),
+      exporter: new OTLPMetricExporter({ headers }),
       exportIntervalMillis: 60_000,
     }),
     instrumentations: [


### PR DESCRIPTION
## Why

Grafana rejected every OTLP export with `401 'no credentials provided'`. The `OTEL_EXPORTER_OTLP_HEADERS` env var was not being applied by the exporters (spans were generated and sent, but without the Authorization header).

## What

Build the Basic auth header in code from two new env vars, `GRAFANA_OTLP_INSTANCE_ID` and `GRAFANA_OTLP_TOKEN`, and pass it directly to the trace and metric exporters. Verified locally that the header (`Basic base64(instanceID:token)`) is sent on the wire.

## Heroku config change needed after deploy

Remove `OTEL_EXPORTER_OTLP_HEADERS` and add:
- `GRAFANA_OTLP_INSTANCE_ID=1746003`
- `GRAFANA_OTLP_TOKEN=<your token>`

`OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` stay as-is.