### PR TITLE
fix(wolt): batch restaurants requests to stop relay timeouts

### DIFF
--- a/src/features/wolt/utils/get-restaurants-data.ts
+++ b/src/features/wolt/utils/get-restaurants-data.ts
@@ -1,8 +1,16 @@
 import axios from 'axios';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { chunk, Logger, sleep } from '@core/utils';
 import type { WoltRestaurant } from '@shared/wolt';
-import { CITIES_BASE_URL, CITIES_SLUGS_SUPPORTED, RESTAURANT_LINK_BASE_URL, RESTAURANTS_BASE_URL } from '../wolt.config';
+import {
+  CITIES_BASE_URL,
+  CITIES_SLUGS_SUPPORTED,
+  DELAY_BETWEEN_RESTAURANTS_BATCHES_MS,
+  MAX_CONCURRENT_RESTAURANTS_REQUESTS,
+  RELAY_REQUEST_TIMEOUT_MS,
+  RESTAURANT_LINK_BASE_URL,
+  RESTAURANTS_BASE_URL,
+} from '../wolt.config';
 
 type WoltCity = {
   readonly lat: number;
@@ -22,39 +30,64 @@ function buildRestaurantsUrl(lat: number, lon: number): string {
   return `${RESTAURANTS_BASE_URL}?lat=${lat}&lon=${lon}`;
 }
 
+async function fetchCityRestaurants(city: WoltCity): Promise<WoltRestaurant[]> {
+  const url = buildRestaurantsUrl(city.lat, city.lon);
+  // Apps Script follows a 302 to a googleusercontent download URL, so the relay needs more than the
+  // global 30s axios default to finish a multi-megabyte response.
+  const timeout = env.WOLT_RELAY_URL ? RELAY_REQUEST_TIMEOUT_MS : undefined;
+  const { data } = await axios.get(url, { timeout });
+  const items = data?.sections?.[1]?.items ?? [];
+
+  return items.map((item) => {
+    const { venue, title: name, image } = item;
+    const { id, online: isOnline, slug, tags, price_range: priceRange, rating, estimate, short_description: shortDescription } = venue;
+    const link = RESTAURANT_LINK_BASE_URL.replace('{area}', city.areaSlug).replace('{slug}', slug);
+    return {
+      id,
+      name,
+      isOnline,
+      slug,
+      area: city.areaSlug,
+      photo: image.url,
+      link,
+      tags: Array.isArray(tags) ? tags : undefined,
+      priceRange: typeof priceRange === 'number' ? priceRange : undefined,
+      rating: rating && typeof rating.score === 'number' ? rating.score : undefined,
+      estimateMinutes: typeof estimate === 'number' ? estimate : undefined,
+      shortDescription: typeof shortDescription === 'string' ? shortDescription : undefined,
+    } as WoltRestaurant;
+  });
+}
+
 export async function getRestaurantsList(): Promise<WoltRestaurant[]> {
   const logger = new Logger(getRestaurantsList.name);
   try {
     const cities = await getCitiesList();
-    const responses = await Promise.all(cities.map(({ lat, lon }: WoltCity) => axios.get(buildRestaurantsUrl(lat, lon))));
+    const restaurants: WoltRestaurant[] = [];
+    const failedAreas: string[] = [];
 
-    const restaurantsWithArea = responses
-      .map((res, index) => {
-        const restaurants = res.data.sections[1].items;
-        restaurants.map((restaurant) => (restaurant.area = cities[index].areaSlug));
-        return restaurants;
-      })
-      .flat();
+    // Both the relay (Apps Script serializes invocations) and Wolt's edge (429s on bursts) choke when all
+    // cities are requested at once, so walk through them in small batches.
+    const batches = chunk(cities, MAX_CONCURRENT_RESTAURANTS_REQUESTS);
+    for (const [batchIndex, batch] of batches.entries()) {
+      const results = await Promise.allSettled(batch.map((city) => fetchCityRestaurants(city)));
+      results.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          restaurants.push(...result.value);
+        } else {
+          failedAreas.push(`${batch[index].areaSlug} (${result.reason})`);
+        }
+      });
+      if (batchIndex < batches.length - 1) {
+        await sleep(DELAY_BETWEEN_RESTAURANTS_BATCHES_MS);
+      }
+    }
 
-    return restaurantsWithArea.map((restaurant) => {
-      const { venue, title: name, area, image } = restaurant;
-      const { id, online: isOnline, slug, tags, price_range: priceRange, rating, estimate, short_description: shortDescription } = venue;
-      const link = RESTAURANT_LINK_BASE_URL.replace('{area}', area).replace('{slug}', slug);
-      return {
-        id,
-        name,
-        isOnline,
-        slug,
-        area,
-        photo: image.url,
-        link,
-        tags: Array.isArray(tags) ? tags : undefined,
-        priceRange: typeof priceRange === 'number' ? priceRange : undefined,
-        rating: rating && typeof rating.score === 'number' ? rating.score : undefined,
-        estimateMinutes: typeof estimate === 'number' ? estimate : undefined,
-        shortDescription: typeof shortDescription === 'string' ? shortDescription : undefined,
-      } as WoltRestaurant;
-    });
+    if (failedAreas.length) {
+      logger.warn(`${getRestaurantsList.name} - could not fetch restaurants for areas: ${failedAreas.join(', ')}`);
+    }
+
+    return restaurants;
   } catch (err) {
     logger.error(`${getRestaurantsList.name} - err - ${err}`);
     return [];

--- a/src/features/wolt/wolt.config.ts
+++ b/src/features/wolt/wolt.config.ts
@@ -29,6 +29,14 @@ export const TOO_OLD_LIST_THRESHOLD_MS = 60000;
 export const MIN_HOUR_TO_ALERT_USER = 8;
 export const MAX_HOUR_TO_ALERT_USER = 1;
 
+// The restaurants endpoint returns 1-3MB per city and answers bursts with 429s. When routed through
+// WOLT_RELAY_URL (a free Google Apps Script web app) the relay also serializes concurrent invocations, so
+// fanning out all cities at once queues them up until they exceed the global 30s axios timeout. Fetch the
+// cities in small batches instead, and give relay requests extra headroom over the global timeout.
+export const MAX_CONCURRENT_RESTAURANTS_REQUESTS = 2;
+export const DELAY_BETWEEN_RESTAURANTS_BATCHES_MS = 500;
+export const RELAY_REQUEST_TIMEOUT_MS = 45_000;
+
 export const CITIES_BASE_URL = 'https://restaurant-api.wolt.com/v1/cities';
 export const RESTAURANTS_BASE_URL = 'https://restaurant-api.wolt.com/v1/pages/restaurants';
 export const RESTAURANT_LINK_BASE_URL = 'https://wolt.com/en/isr/{area}/restaurant/{slug}';


### PR DESCRIPTION
## Why

Grafana started firing an `error logs` alert from the notifier:

```
[getRestaurantsList] getRestaurantsList - err - AxiosError: timeout of 30000ms exceeded
```

Every time this fired, `getRestaurantsList()` returned `[]`, so the Wolt bot had zero restaurants: subscription alerts could not match anything and searches replied "no restaurants found".

The Apps Script relay itself is fine. The calling pattern was the problem. `getRestaurantsList()` fanned out all 7 supported cities at once with `Promise.all`, but Apps Script web apps serialize concurrent invocations per user. Requests 3-7 sat in a queue while 1-2 ran, and blew past the global `axios.defaults.timeout = 30_000` set in `src/index.ts`.

Three factors compounded:

1. **Serialization.** Even at concurrency 2 against the smallest city I reproduced a 30s timeout.
2. **Payload size.** Tel Aviv alone is 2.95MB uncompressed, and Apps Script 302-redirects to a googleusercontent URL, adding a second round trip.
3. **`Promise.all` is all-or-nothing.** One slow city discarded all 7 responses, turning a partial degradation into a total outage.

## Approach

- Fetch cities in batches of `MAX_CONCURRENT_RESTAURANTS_REQUESTS = 2` with a 500ms gap between batches, instead of all 7 at once.
- Switch to `Promise.allSettled` per batch so one failing city logs a warning naming the affected areas and the rest of the list still returns.
- Apply `RELAY_REQUEST_TIMEOUT_MS = 45_000` to relay requests only, giving headroom over the global 30s default for the redirect plus multi-megabyte body. Direct requests keep the global default.
- Extract the per-city parse into `fetchCityRestaurants`, which also removes the old mutation of Wolt's response objects (`restaurant.area = ...`). `area` now comes from the city the request was made for.

## Notes for reviewers

The relay is still pulling its weight, so I left it in place. Direct calls to Wolt returned `429` on the 4th consecutive cycle in my testing, which is exactly the rate limiting the relay was added to work around.

Latency is now roughly 13s for a full refresh through the relay. That is well inside the scheduler's 30s peak interval, but it is dominated by relay payload size rather than anything in this code. Slimming the Apps Script response to only the fields the parser reads would cut Tel Aviv from 2.95MB to 0.51MB (5.7x). I verified that shape still satisfies the parser contract, but it is a change to the external script rather than this repo, so it is not included here.

## Validation

| Check | Result |
| --- | --- |
| Old code, 5 runs at production cadence against the live relay | 2/5 failed, reproducing the exact alert message |
| New code, 5 runs, same conditions | 0/5 failed, 4035 restaurants, ~13s steady |
| Direct path with `WOLT_RELAY_URL` unset | 4035 restaurants, 6-8s |
| `tsc --noEmit`, eslint, prettier | clean |
| `vitest run` | 580 passed |

Graceful degradation was confirmed in practice, not just in theory: one mid-test run lost `petah-tikva` and returned 3545 restaurants with a warning instead of failing outright.
