### PR TITLE
feat(chatbot): add snooze and done buttons to reminder alerts

### DIFF
--- a/src/features/chatbot/chatbot.controller.ts
+++ b/src/features/chatbot/chatbot.controller.ts
@@ -7,9 +7,11 @@ import { deleteFile } from '@core/utils';
 import { imgurUploadImage } from '@services/imgur';
 import { analyzeImage } from '@services/openai/utils/analyze-image';
 import { getTranscriptFromAudio } from '@services/openai/utils/get-transcript-from-audio';
-import { downloadFile, getMessageData, MessageLoader, sendRichMessage } from '@services/telegram';
+import { downloadFile, getCallbackQueryData, getMessageData, MessageLoader, sendRichMessage } from '@services/telegram';
+import { getReminderById, updateReminderStatus } from '@shared/reminders';
 import { IMAGE_ANALYSIS_PROMPT } from './chatbot.config';
 import { ChatbotService } from './chatbot.service';
+import { describeSnoozeOption, parseReminderCallbackData, resolveSnoozeUntil } from './schedulers';
 
 export class ChatbotController {
   private readonly logger = new Logger(ChatbotController.name);
@@ -25,10 +27,46 @@ export class ChatbotController {
     this.bot.on('message:text', (ctx) => this.messageHandler(ctx));
     this.bot.on('message:photo', (ctx) => this.photoHandler(ctx));
     this.bot.on(['message:audio', 'message:voice'], (ctx) => this.audioHandler(ctx));
+    this.bot.on('callback_query:data', (ctx) => this.callbackQueryHandler(ctx));
   }
 
   private async startHandler(ctx: Context): Promise<void> {
     await ctx.reply('Hi, I am your chatbot! How can I assist you today?');
+  }
+
+  private async callbackQueryHandler(ctx: Context): Promise<void> {
+    const { chatId, data } = getCallbackQueryData(ctx);
+
+    const parsed = parseReminderCallbackData(data);
+    if (!parsed) {
+      await ctx.answerCallbackQuery().catch(() => {});
+      return;
+    }
+
+    try {
+      const reminder = await getReminderById(parsed.reminderId, chatId);
+      if (!reminder) {
+        await ctx.answerCallbackQuery({ text: 'Reminder not found.', show_alert: true }).catch(() => {});
+        return;
+      }
+
+      if (parsed.action === 'done') {
+        await updateReminderStatus(parsed.reminderId, chatId, 'completed');
+        await ctx.editMessageText(`✅ *Done*\n${reminder.message}`, { parse_mode: 'Markdown' }).catch(() => {});
+        await ctx.answerCallbackQuery({ text: 'Marked as done' }).catch(() => {});
+        return;
+      }
+
+      const option = parsed.option ?? '1h';
+      const snoozeUntil = resolveSnoozeUntil(option);
+      await updateReminderStatus(parsed.reminderId, chatId, 'snoozed', snoozeUntil);
+      const label = describeSnoozeOption(option);
+      await ctx.editMessageText(`😴 *Snoozed for ${label}*\n${reminder.message}`, { parse_mode: 'Markdown' }).catch(() => {});
+      await ctx.answerCallbackQuery({ text: `Snoozed for ${label}` }).catch(() => {});
+    } catch (err) {
+      this.logger.error(`Error handling reminder callback: ${err}`);
+      await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
+    }
   }
 
   private async exerciseHandler(ctx: Context): Promise<void> {

--- a/src/features/chatbot/schedulers/index.ts
+++ b/src/features/chatbot/schedulers/index.ts
@@ -8,6 +8,8 @@ export { footballUpdate } from './football-update';
 export { footballPredictionsResults } from './football-predictions-results';
 export { makavdiaUpdate } from './makavdia-update';
 export { reminderCheck } from './reminder-check';
+export { buildReminderKeyboard, parseReminderCallbackData, resolveSnoozeUntil, describeSnoozeOption } from './reminder-actions';
+export type { ReminderAction, ReminderSnoozeOption, ParsedReminderCallback } from './reminder-actions';
 export { sportsCalendar } from './sports-calendar';
 export { weeklyExerciseSummary } from './weekly-exercise-summary';
 export { polymarketUpdate } from './polymarket-update';

--- a/src/features/chatbot/schedulers/reminder-actions.ts
+++ b/src/features/chatbot/schedulers/reminder-actions.ts
@@ -1,0 +1,67 @@
+import { addDays, set } from 'date-fns';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import { InlineKeyboard } from 'grammy';
+import { DEFAULT_TIMEZONE } from '@core/config';
+
+export const REMINDER_ACTION_PREFIX = 'reminder';
+
+export type ReminderAction = 'snooze' | 'done';
+export type ReminderSnoozeOption = '1h' | '3h' | 'morning';
+
+const TOMORROW_MORNING_HOUR = 9;
+
+export function buildReminderCallbackData(action: ReminderAction, reminderId: string, option?: ReminderSnoozeOption): string {
+  return [REMINDER_ACTION_PREFIX, action, reminderId, option].filter(Boolean).join(':');
+}
+
+export type ParsedReminderCallback = {
+  readonly action: ReminderAction;
+  readonly reminderId: string;
+  readonly option?: ReminderSnoozeOption;
+};
+
+export function parseReminderCallbackData(data: string): ParsedReminderCallback | null {
+  const [prefix, action, reminderId, option] = data.split(':');
+  if (prefix !== REMINDER_ACTION_PREFIX || !reminderId) {
+    return null;
+  }
+  if (action !== 'snooze' && action !== 'done') {
+    return null;
+  }
+  return { action: action as ReminderAction, reminderId, option: option as ReminderSnoozeOption | undefined };
+}
+
+export function buildReminderKeyboard(reminderId: string): InlineKeyboard {
+  return new InlineKeyboard()
+    .text('😴 1h', buildReminderCallbackData('snooze', reminderId, '1h'))
+    .text('😴 3h', buildReminderCallbackData('snooze', reminderId, '3h'))
+    .row()
+    .text('🌅 Tomorrow morning', buildReminderCallbackData('snooze', reminderId, 'morning'))
+    .row()
+    .text('✅ Done', buildReminderCallbackData('done', reminderId));
+}
+
+export function resolveSnoozeUntil(option: ReminderSnoozeOption, now: Date = new Date()): Date {
+  switch (option) {
+    case '1h':
+      return new Date(now.getTime() + 60 * 60 * 1000);
+    case '3h':
+      return new Date(now.getTime() + 3 * 60 * 60 * 1000);
+    case 'morning': {
+      const zonedNow = toZonedTime(now, DEFAULT_TIMEZONE);
+      const zonedTomorrowMorning = set(addDays(zonedNow, 1), { hours: TOMORROW_MORNING_HOUR, minutes: 0, seconds: 0, milliseconds: 0 });
+      return fromZonedTime(zonedTomorrowMorning, DEFAULT_TIMEZONE);
+    }
+  }
+}
+
+export function describeSnoozeOption(option: ReminderSnoozeOption): string {
+  switch (option) {
+    case '1h':
+      return '1 hour';
+    case '3h':
+      return '3 hours';
+    case 'morning':
+      return 'tomorrow morning';
+  }
+}

--- a/src/features/chatbot/schedulers/reminder-check.ts
+++ b/src/features/chatbot/schedulers/reminder-check.ts
@@ -2,6 +2,7 @@ import type { Bot } from 'grammy';
 import { DEFAULT_TIMEZONE } from '@core/config';
 import { Logger } from '@core/utils';
 import { getDueReminders, markReminderNotified, reactivateSnoozedReminders } from '@shared/reminders';
+import { buildReminderKeyboard } from './reminder-actions';
 
 const logger = new Logger('ReminderCheckScheduler');
 
@@ -25,7 +26,7 @@ export async function reminderCheck(bot: Bot): Promise<void> {
           timeStyle: 'short',
         })}_`;
 
-        await bot.api.sendMessage(reminder.chatId, message, { parse_mode: 'Markdown' });
+        await bot.api.sendMessage(reminder.chatId, message, { parse_mode: 'Markdown', reply_markup: buildReminderKeyboard(reminder._id.toString()) });
 
         await markReminderNotified(reminder._id, reminder.chatId);
 

--- a/src/shared/reminders/mongo/reminder.repository.ts
+++ b/src/shared/reminders/mongo/reminder.repository.ts
@@ -119,7 +119,10 @@ export async function reactivateSnoozedReminders(): Promise<number> {
   const remindersCollection = getCollection();
   const now = new Date();
 
-  const result = await remindersCollection.updateMany({ status: 'snoozed', snoozedUntil: { $lte: now } }, { $set: { status: 'pending' }, $unset: { snoozedUntil: '' } });
+  const result = await remindersCollection.updateMany(
+    { status: 'snoozed', snoozedUntil: { $lte: now } },
+    { $set: { status: 'pending' }, $unset: { snoozedUntil: '', notifiedAt: '' } },
+  );
 
   return result.modifiedCount;
 }


### PR DESCRIPTION
## Why

Reminder alerts were plain text with no way to act on them. If a reminder fired at a bad time, the only option was to ask the chatbot to reschedule it in a follow-up message. Since the bot's normal replies come from the LLM, it isn't possible to attach interactive buttons to those messages, which made a quick one-tap snooze feel out of reach.

## Approach

The key realization is that reminder notifications are **not** sent by the LLM at all. They are sent by the `reminderCheck` cron scheduler via `bot.api.sendMessage`, completely outside the agent loop, so we are free to attach an inline keyboard.

- Each `🔔 Reminder` message now carries a keyboard: `😴 1h`, `😴 3h`, `🌅 Tomorrow morning`, and `✅ Done`.
- A new `reminder-actions.ts` module owns the `callback_data` encoding/parsing and snooze-target math (tomorrow morning resolves to 09:00 in `Asia/Jerusalem`), keeping the scheduler and controller in sync.
- The chatbot controller gains a `callback_query:data` handler (it had none before) that snoozes or completes the reminder, edits the original message to show the outcome, and answers the callback query. Non-reminder callbacks are silently acknowledged.

## Non-obvious detail

Snoozing reuses the existing `status: 'snoozed'` + `snoozedUntil` fields and the reactivation cron that already runs every 15 minutes. But a subtle bug would have prevented snoozed reminders from ever re-firing: `getDueReminders` filters on `notifiedAt` not existing, and reactivation only cleared `snoozedUntil`. So `reactivateSnoozedReminders` now also unsets `notifiedAt`, letting a reactivated reminder fire again once its snooze window elapses.

`callback_data` stays well under Telegram's 64-byte cap (about 40 bytes with a 24-char ObjectId).

## Validation

- `npm run typecheck` passes with 0 errors.
- ESLint on all changed files: 0 errors (only pre-existing warnings unrelated to this change).
- No new dependencies.
