### PR TITLE
refactor(secretary): pause reply suggestions

### DIFF
--- a/src/features/secretary/secretary.controller.ts
+++ b/src/features/secretary/secretary.controller.ts
@@ -156,10 +156,12 @@ export class SecretaryController {
   private async updateDraftFlow(chatId: number, fromOwner: boolean, businessConnectionId?: string): Promise<void> {
     if (isProd && chatId !== TOODIE_USER_ID) return;
     if (fromOwner) {
-      await this.draftService.onOwnerReply(chatId);
+      // Reply suggestions paused for now — re-enable by uncommenting this line.
+      // await this.draftService.onOwnerReply(chatId);
       await this.nudgeService.onOwnerReply(chatId);
     } else {
-      this.draftService.scheduleSuggestion(chatId, businessConnectionId);
+      // Reply suggestions paused for now — re-enable by uncommenting this line.
+      // this.draftService.scheduleSuggestion(chatId, businessConnectionId);
       this.nudgeService.scheduleNudge(chatId, businessConnectionId);
     }
   }


### PR DESCRIPTION
## Why

The secretary bot's smart-reply suggestion feature is being paused for now. We want to stop generating draft reply suggestions without ripping out the code, so it stays easy to bring back later.

## What

In `updateDraftFlow` (secretary.controller.ts), the two `draftService` calls that drive reply suggestions are commented out:

- `draftService.onOwnerReply(chatId)` (fired when the owner replies)
- `draftService.scheduleSuggestion(chatId, businessConnectionId)` (fired when the other person messages)

Each line has a note explaining how to re-enable it. This is the smallest possible change: 2 lines commented, everything else untouched.

## What still works

- End-of-day daily summaries with their one-tap action buttons (independent, in the scheduler)
- Forgotten-reply nudges, mid-week check-in prompts, and voice transcription
- All `draftService` code, callback handlers, and the class stay intact for an easy revival

To bring the feature back, uncomment the two lines.
