### PR TITLE
feat(chatbot): add morning brief scheduler

### DIFF
--- a/src/features/chatbot/chatbot-scheduler.service.ts
+++ b/src/features/chatbot/chatbot-scheduler.service.ts
@@ -10,6 +10,7 @@ import {
   exerciseReminder,
   footballUpdate,
   makavdiaUpdate,
+  morningBrief,
   polymarketUpdate,
   // rainRadarAlert,
   reminderCheck,
@@ -37,6 +38,8 @@ export class ChatbotSchedulerService {
 
   init(): void {
     createSchedule(`00 23 * * *`, async () => dailySummary(this.bot, this.chatbotService));
+
+    createSchedule(`00 8 * * *`, async () => morningBrief(this.bot, this.chatbotService));
 
     createSchedule(`00 18 * * *`, async () => birthdayReminder(this.bot));
 

--- a/src/features/chatbot/schedulers/index.ts
+++ b/src/features/chatbot/schedulers/index.ts
@@ -1,5 +1,6 @@
 export { birthdayReminder } from './birthday-reminder';
 export { dailySummary } from './daily-summary';
+export { morningBrief } from './morning-brief';
 export { earthquakeMonitor } from './earthquake-monitor';
 export { emailSummary } from './email-summary';
 export { exerciseReminder } from './exercise-reminder';

--- a/src/features/chatbot/schedulers/morning-brief.ts
+++ b/src/features/chatbot/schedulers/morning-brief.ts
@@ -1,0 +1,56 @@
+import { endOfDay } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
+import type { Bot } from 'grammy';
+import { DEFAULT_TIMEZONE, MY_USER_ID } from '@core/config';
+import { Logger } from '@core/utils';
+import { sendShortenedMessage } from '@services/telegram';
+import { getTodayEvents } from '@shared/calendar-events';
+import { getPendingRemindersDueOnOrBefore } from '@shared/reminders';
+import type { ChatbotService } from '../chatbot.service';
+import { formatEventsForPrompt } from './utils/events';
+
+const logger = new Logger('MorningBriefScheduler');
+
+const WEATHER_LOCATION = 'Kfar Saba';
+
+export async function morningBrief(bot: Bot, chatbotService: ChatbotService): Promise<void> {
+  try {
+    const now = new Date();
+    const endOfToday = endOfDay(toZonedTime(now, DEFAULT_TIMEZONE));
+
+    const [events, dueReminders] = await Promise.all([getTodayEvents(), getPendingRemindersDueOnOrBefore(MY_USER_ID, endOfToday)]);
+
+    const calendarSection = events.length > 0 ? `Here are my calendar events for today:\n${formatEventsForPrompt(events)}` : 'No events scheduled for today.';
+
+    const remindersSection = dueReminders.length > 0 ? `Here are my reminders due today:\n${dueReminders.map((reminder) => `- ${reminder.message}`).join('\n')}` : 'No reminders due today.';
+
+    const prompt = `Good morning! Please create my morning brief with the following information:
+
+**Weather for Today:**
+Use the weather tool with action "current" for location "${WEATHER_LOCATION}" to get the current conditions.
+Summarize the weather in one short, friendly line (temperature and conditions, whether I should take an umbrella or dress warm).
+
+**Calendar:**
+${calendarSection}
+Format as a bulleted list where each event has its own bullet point. Do NOT use the calendar tool — the data is already provided above.
+
+**Reminders due today:**
+${remindersSection}
+Format as a bulleted list. Do NOT use the reminders tool — the data is already provided above.
+
+**Unread Email:**
+Use the gmail tool with action "list" and query "is:unread" to fetch my unread emails.
+Report only the count and, if there are any, a one-line summary of the most important 1-3 (sender + subject). Keep it brief.
+
+Please format the response nicely with emojis and make it feel like a friendly good morning message. Start with a short warm greeting like "☀️ Good morning!" and end with a short encouraging note to start the day.`;
+
+    const response = await chatbotService.processMessage(prompt, MY_USER_ID);
+
+    if (response?.message) {
+      await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
+    }
+  } catch (err) {
+    await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your morning brief.').catch(() => {});
+    logger.error(`Failed to generate/send morning brief: ${err}`);
+  }
+}


### PR DESCRIPTION
## Why

I already get a nightly summary before bed, but mornings still required me to reactively check several apps: calendar, weather, reminders, and email. This adds the mirror-image push so the day's context arrives in one message and there's nothing to go ask for.

## Approach

Adds a `morningBrief` scheduler that runs daily at 08:00 (`Asia/Jerusalem`) and mirrors the existing `dailySummary` pattern, but scoped to *today*:

- Calendar: `getTodayEvents()`, formatted with the existing `formatEventsForPrompt` helper.
- Reminders: `getPendingRemindersDueOnOrBefore(MY_USER_ID, endOfToday)` to list what's due today.
- Weather: the chatbot's `weather` tool (`current` action for Kfar Saba) for a one-line outlook.
- Email: the `gmail` tool (`list` / `is:unread`) for an unread count plus the top 1-3.

Calendar and reminder data are fetched directly and passed into the prompt (the prompt explicitly tells the agent not to re-fetch them), so only weather and gmail cost tool calls. Failure sends a short fallback message and logs, matching `dailySummary`.

## Notes

- Weather has no "today hourly" action, so I used `current` for a quick outlook rather than adding a new tool action; can expand later if you want hourly.
- Wired into `ChatbotSchedulerService` next to the nightly summary. No new dependencies.

## Validation

- `npm run typecheck`: 0 errors.
- ESLint on changed files: 0 issues.
