### PR TITLE
feat(chatbot): add deploy and merge-pr github tool actions

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   deploy:
     name: 'Deploy to Heroku'
-    if: github.actor == 'matansocher'
+    if: github.actor == 'matansocher' || contains(github.actor, 'mmps-companion')
     runs-on: ubuntu-latest
     environment:
       name: production

--- a/src/features/chatbot/agent/agent.ts
+++ b/src/features/chatbot/agent/agent.ts
@@ -169,6 +169,14 @@ GitHub AI Labels Guidelines:
   * implement: Generate implementation code and create a pull request from the issue
 - Confirm to the user that the workflow has been triggered and they'll see results as a new comment/PR
 - Only add these labels when explicitly requested or when user mentions wanting AI code review/generation
+- DEPLOYMENT FLOW:
+  * When the user asks to deploy (e.g. "deploy mmps", "deploy the repo", "ship it to production", "trigger a deploy", "release to Heroku"), use the "deploy" action. This dispatches the Heroku deploy GitHub Actions workflow on the matansocher/mmps repo.
+  * When the user does not mention a repository, assume matansocher/mmps.
+  * After triggering, confirm to the user that the deploy workflow was dispatched. If the tool returns success: false, relay the error briefly.
+- MERGE PR FLOW:
+  * When the user asks to merge a pull request (e.g. "merge PR 42", "merge that PR", "squash and merge #42"), use the "merge_pr" action with the prNumber. The default strategy is squash; only pass mergeMethod when the user explicitly asks for merge/rebase.
+  * When the user does not mention a repository, assume matansocher/mmps.
+  * After merging, confirm the result. If the tool returns success: false (e.g. failing checks, conflicts, not mergeable), relay the error briefly.
 
 
 Smart Reminders Guidelines:

--- a/src/services/github/constants.ts
+++ b/src/services/github/constants.ts
@@ -1,3 +1,6 @@
 export const GITHUB_REPO_OWNER = 'matansocher';
 export const GITHUB_REPO_NAME = 'mmps';
 export const GITHUB_REPO = `${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}`;
+
+export const HEROKU_DEPLOY_WORKFLOW_FILE = 'heroku-deploy.yml';
+export const HEROKU_DEPLOY_DEFAULT_REF = 'main';

--- a/src/services/github/index.ts
+++ b/src/services/github/index.ts
@@ -11,6 +11,8 @@ export {
   getPullRequest,
   listPRFiles,
   getPRReviews,
+  triggerWorkflow,
+  mergePullRequest,
 } from './utils';
 export * from './types';
-export { GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_REPO } from './constants';
+export { GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_REPO, HEROKU_DEPLOY_WORKFLOW_FILE, HEROKU_DEPLOY_DEFAULT_REF } from './constants';

--- a/src/services/github/types.ts
+++ b/src/services/github/types.ts
@@ -76,3 +76,14 @@ export type GitHubServiceResponse<T> = {
   readonly data?: T;
   readonly error?: string;
 };
+
+export type TriggerWorkflowResult = {
+  readonly workflow: string;
+  readonly ref: string;
+};
+
+export type MergePullRequestResult = {
+  readonly merged: boolean;
+  readonly message: string;
+  readonly sha?: string;
+};

--- a/src/services/github/utils/index.ts
+++ b/src/services/github/utils/index.ts
@@ -10,4 +10,6 @@ export { getPRChecks } from './get-pr-checks';
 export { getPullRequest } from './get-pull-request';
 export { listPRFiles } from './list-pr-files';
 export { getPRReviews } from './get-pr-reviews';
+export { triggerWorkflow } from './trigger-workflow';
+export { mergePullRequest } from './merge-pull-request';
 export { initOctokit } from './octokit';

--- a/src/services/github/utils/merge-pull-request.ts
+++ b/src/services/github/utils/merge-pull-request.ts
@@ -1,0 +1,36 @@
+import { Logger } from '@core/utils';
+import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
+import type { GitHubServiceResponse, MergePullRequestResult } from '../types';
+import { getOctokit } from './octokit';
+
+const logger = new Logger('MergePullRequest');
+
+type MergeMethod = 'merge' | 'squash' | 'rebase';
+
+export async function mergePullRequest(prNumber: number, mergeMethod: MergeMethod = 'squash'): Promise<GitHubServiceResponse<MergePullRequestResult>> {
+  try {
+    const octokit = getOctokit();
+    const response = await octokit.pulls.merge({
+      owner: GITHUB_REPO_OWNER,
+      repo: GITHUB_REPO_NAME,
+      pull_number: prNumber,
+      merge_method: mergeMethod,
+    });
+
+    return {
+      success: true,
+      data: {
+        merged: response.data.merged,
+        message: response.data.message,
+        sha: response.data.sha,
+      },
+    };
+  } catch (err) {
+    const errorMsg = `Failed to merge PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    logger.error(errorMsg);
+    return {
+      success: false,
+      error: errorMsg,
+    };
+  }
+}

--- a/src/services/github/utils/trigger-workflow.ts
+++ b/src/services/github/utils/trigger-workflow.ts
@@ -1,0 +1,30 @@
+import { Logger } from '@core/utils';
+import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER, HEROKU_DEPLOY_DEFAULT_REF } from '../constants';
+import type { GitHubServiceResponse, TriggerWorkflowResult } from '../types';
+import { getOctokit } from './octokit';
+
+const logger = new Logger('TriggerWorkflow');
+
+export async function triggerWorkflow(workflowFile: string, ref: string = HEROKU_DEPLOY_DEFAULT_REF): Promise<GitHubServiceResponse<TriggerWorkflowResult>> {
+  try {
+    const octokit = getOctokit();
+    await octokit.actions.createWorkflowDispatch({
+      owner: GITHUB_REPO_OWNER,
+      repo: GITHUB_REPO_NAME,
+      workflow_id: workflowFile,
+      ref,
+    });
+
+    return {
+      success: true,
+      data: { workflow: workflowFile, ref },
+    };
+  } catch (err) {
+    const errorMsg = `Failed to trigger workflow '${workflowFile}' on ref '${ref}': ${err instanceof Error ? err.message : String(err)}`;
+    logger.error(errorMsg);
+    return {
+      success: false,
+      error: errorMsg,
+    };
+  }
+}

--- a/src/shared/ai/tools/github/github.tool.ts
+++ b/src/shared/ai/tools/github/github.tool.ts
@@ -9,15 +9,18 @@ import {
   getPRChecks,
   getPRReviews,
   getPullRequest,
+  HEROKU_DEPLOY_WORKFLOW_FILE,
   listIssues,
   listPRFiles,
   listPullRequests,
+  mergePullRequest,
+  triggerWorkflow,
   updateIssue,
 } from '@services/github';
 
 const schema = z.object({
   action: z
-    .enum(['create_issue', 'get_issue', 'update_issue', 'comment_issue', 'comment_pr', 'add_labels', 'list_issues', 'list_prs', 'get_pr_checks', 'get_pr', 'list_pr_files', 'get_pr_reviews'])
+    .enum(['create_issue', 'get_issue', 'update_issue', 'comment_issue', 'comment_pr', 'add_labels', 'list_issues', 'list_prs', 'get_pr_checks', 'get_pr', 'list_pr_files', 'get_pr_reviews', 'deploy', 'merge_pr'])
     .describe('The GitHub action to perform'),
   title: z.string().optional().describe('Issue title (for create_issue and update_issue)'),
   body: z.string().optional().describe('Issue/comment body text'),
@@ -26,6 +29,7 @@ const schema = z.object({
   labels: z.array(z.string()).optional().describe('Labels to assign to issue'),
   assignees: z.array(z.string()).optional().describe('GitHub usernames to assign'),
   state: z.enum(['open', 'closed']).optional().describe('Issue/PR state filter'),
+  mergeMethod: z.enum(['merge', 'squash', 'rebase']).optional().describe('Merge strategy for merge_pr (defaults to squash)'),
 });
 
 async function runner(input: z.infer<typeof schema>) {
@@ -118,6 +122,17 @@ async function runner(input: z.infer<typeof schema>) {
       return JSON.stringify(result);
     }
 
+    case 'deploy': {
+      const result = await triggerWorkflow(HEROKU_DEPLOY_WORKFLOW_FILE);
+      return JSON.stringify(result);
+    }
+
+    case 'merge_pr': {
+      if (!input.prNumber) return JSON.stringify({ error: 'prNumber is required for merge_pr' });
+      const result = await mergePullRequest(input.prNumber, input.mergeMethod);
+      return JSON.stringify(result);
+    }
+
     default:
       return JSON.stringify({ error: `Unknown action: ${input.action}` });
   }
@@ -126,6 +141,6 @@ async function runner(input: z.infer<typeof schema>) {
 export const githubTool = tool(runner, {
   name: 'github',
   description:
-    'Interact with the GitHub repository matansocher/mmps (the ONLY repo — never ask the user which repo, branch, or file). Can create, read, update issues and PRs, add labels, list them, and check PR status checks. To build or change anything in the code (a "new feature", bug fix, or behavior change), use create_issue with a detailed description of the request, then add_labels with the "implement" label to that issue to trigger the automated implementation workflow.',
+    'Interact with the GitHub repository matansocher/mmps (the ONLY repo — never ask the user which repo, branch, or file). Can create, read, update issues and PRs, add labels, list them, and check PR status checks. To build or change anything in the code (a "new feature", bug fix, or behavior change), use create_issue with a detailed description of the request, then add_labels with the "implement" label to that issue to trigger the automated implementation workflow. To deploy the repo to production (Heroku), use the "deploy" action, which dispatches the Heroku deploy GitHub Actions workflow. To merge an open pull request into the base branch, use the "merge_pr" action with the PR number (defaults to squash merge).',
   schema,
 });


### PR DESCRIPTION
## Why

I want to tell the chatbot to deploy the repo and to merge PRs through natural language, without touching GitHub myself. Deploying already exists as a `workflow_dispatch` Heroku workflow, and PRs are opened via the issue + `implement` label flow, but the chatbot previously had no way to trigger either a deploy or a merge.

## What changed

- **`deploy` action** on the github tool: dispatches the Heroku deploy workflow (`heroku-deploy.yml`) via `actions.createWorkflowDispatch`. When no repo is mentioned, the chatbot assumes `matansocher/mmps`.
- **`merge_pr` action** on the github tool: merges an open PR by number using `pulls.merge`, defaulting to a squash merge (configurable to merge/rebase).
- **Heroku workflow actor guard**: broadened `if: github.actor == 'matansocher'` to also allow the chatbot GitHub App bot (`contains(github.actor, 'mmps-companion')`), mirroring the existing `implement.yml` guard. Without this, an app-triggered dispatch would authenticate as the bot identity and the deploy job would be silently skipped.
- Agent prompt updated with deploy and merge-pr guidance (assume `matansocher/mmps` when unspecified, relay tool errors briefly).

The service layer follows the existing one-function-per-file pattern (`trigger-workflow.ts`, `merge-pull-request.ts`) with matching barrel exports and result types.

## Note for reviewers / follow-up

These actions require the chatbot's GitHub App installation to have the right repo permissions:

- **Actions: Read and write** for `deploy`.
- **Pull requests: Read and write** (plus Contents: write) for `merge_pr`.

If those scopes are not granted, the calls will 403 at runtime. Branch protection on `main` still applies to `merge_pr` merges.

## Validation

- `npm run typecheck` passes.
- ESLint passes on all changed files.