### PR TITLE
feat(chatbot): duplicate secretary logging, daily digest, and check-in

### DIFF
--- a/src/features/chatbot/chatbot-scheduler.service.ts
+++ b/src/features/chatbot/chatbot-scheduler.service.ts
@@ -3,6 +3,7 @@ import cron from 'node-cron';
 import { DEFAULT_TIMEZONE } from '@core/config';
 import { Logger } from '@core/utils';
 import { ChatbotService } from './chatbot.service';
+import type { SecretaryMessageService } from './secretary';
 import {
   birthdayReminder,
   dailySummary,
@@ -14,6 +15,8 @@ import {
   polymarketUpdate,
   // rainRadarAlert,
   reminderCheck,
+  secretaryCheckIn,
+  secretaryDailyDigest,
   socialMediaCollect,
   socialMediaDigest,
   sportsCalendar,
@@ -34,6 +37,7 @@ export class ChatbotSchedulerService {
   constructor(
     private readonly chatbotService: ChatbotService,
     private readonly bot: Bot,
+    private readonly secretaryMessageService: SecretaryMessageService,
   ) {}
 
   init(): void {
@@ -72,6 +76,10 @@ export class ChatbotSchedulerService {
     createSchedule(`30 * * * *`, async () => socialMediaCollect(['telegram']));
 
     createSchedule(`45 22 * * *`, async () => socialMediaDigest(this.bot));
+
+    createSchedule(`30 23 * * *`, async () => secretaryDailyDigest(this.bot, this.secretaryMessageService));
+
+    createSchedule(`13 11 * * 1,2,3`, async () => secretaryCheckIn(this.bot, this.secretaryMessageService));
 
     // createSchedule(`11 9-23 * * *`, async () => rainRadarAlert(this.bot));
   }

--- a/src/features/chatbot/chatbot.controller.ts
+++ b/src/features/chatbot/chatbot.controller.ts
@@ -1,7 +1,7 @@
 import type { Bot, Context } from 'grammy';
 import type { ReactionTypeEmoji } from 'grammy/types';
 import { env } from 'node:process';
-import { LOCAL_FILES_PATH } from '@core/config';
+import { LOCAL_FILES_PATH, MY_USER_ID, TOODIE_USER_ID } from '@core/config';
 import { Logger } from '@core/utils';
 import { deleteFile } from '@core/utils';
 import { imgurUploadImage } from '@services/imgur';
@@ -13,8 +13,23 @@ import { addExercise } from '@shared/trainer';
 import { IMAGE_ANALYSIS_PROMPT } from './chatbot.config';
 import { ChatbotService } from './chatbot.service';
 import { describeSnoozeOption, parseBirthdayCallbackData, parseExerciseCallbackData, parseReminderCallbackData, resolveSnoozeUntil, sendExerciseReminder } from './schedulers';
+import {
+  ACTION_CALLBACK_PREFIX,
+  buildActionsKeyboard,
+  CHECK_IN_MESSAGE,
+  CHECK_IN_SEND_CALLBACK,
+  getActionByShortId,
+  getActionsByMessageId,
+  OWNER_BUSINESS_CONNECTION_ID,
+  type SecretaryActionService,
+  type SecretaryMessageService,
+  TRANSCRIPTION_HEADER,
+  updateActionStatus,
+} from './secretary';
 
 const EXERCISE_REMIND_DELAY_MS = 60 * 60 * 1000;
+
+const isOwner = (ctx: Context): boolean => ctx.from?.id === MY_USER_ID;
 
 export class ChatbotController {
   private readonly logger = new Logger(ChatbotController.name);
@@ -22,11 +37,17 @@ export class ChatbotController {
   constructor(
     private readonly chatbotService: ChatbotService,
     private readonly bot: Bot,
+    private readonly secretaryMessageService: SecretaryMessageService,
+    private readonly secretaryActionService: SecretaryActionService,
   ) {}
 
   init(): void {
     this.bot.command('start', (ctx) => this.startHandler(ctx));
     this.bot.command('exercise', (ctx) => this.exerciseHandler(ctx));
+    this.bot.on('business_connection', (ctx) => this.businessConnectionHandler(ctx));
+    this.bot.on('business_message', (ctx) => this.businessMessageHandler(ctx));
+    this.bot.callbackQuery(CHECK_IN_SEND_CALLBACK, (ctx) => this.checkInSendHandler(ctx));
+    this.bot.callbackQuery(new RegExp(`^${ACTION_CALLBACK_PREFIX}`), (ctx) => this.secretaryActionHandler(ctx));
     this.bot.on('message:text', (ctx) => this.messageHandler(ctx));
     this.bot.on('message:photo', (ctx) => this.photoHandler(ctx));
     this.bot.on(['message:audio', 'message:voice'], (ctx) => this.audioHandler(ctx));
@@ -35,6 +56,109 @@ export class ChatbotController {
 
   private async startHandler(ctx: Context): Promise<void> {
     await ctx.reply('Hi, I am your chatbot! How can I assist you today?');
+  }
+
+  private businessConnectionHandler(ctx: Context): void {
+    const connection = ctx.businessConnection;
+    if (!connection) return;
+    this.logger.log(`Business connection: id=${connection.id} enabled=${connection.is_enabled} userChatId=${connection.user_chat_id}`);
+  }
+
+  // Log every business-chat message (both sides). Voice notes are transcribed, echoed into the
+  // chat as the owner, and stored so the daily summary stays complete.
+  private async businessMessageHandler(ctx: Context): Promise<void> {
+    const message = ctx.businessMessage;
+    if (!message) return;
+
+    const chatId = message.chat.id;
+    const fromOwner = ctx.from?.id === MY_USER_ID;
+    const senderName = ctx.from?.first_name ?? undefined;
+    const senderUsername = ctx.from?.username ?? undefined;
+    const businessConnectionId = message.business_connection_id;
+
+    const voiceFileId = message.voice?.file_id ?? message.audio?.file_id;
+
+    if (voiceFileId) {
+      const transcript = await this.transcribeBusinessVoice(voiceFileId);
+      if (transcript) {
+        await this.bot.api.sendMessage(chatId, `${TRANSCRIPTION_HEADER}\n${transcript}`, businessConnectionId ? { business_connection_id: businessConnectionId } : undefined);
+        await this.secretaryMessageService.storeMessage({ chatId, fromOwner, text: transcript, transcribed: true, senderName, senderUsername });
+      }
+      return;
+    }
+
+    const text = message.text ?? message.caption;
+    if (!text) return;
+
+    await this.secretaryMessageService.storeMessage({ chatId, fromOwner, text, senderName, senderUsername });
+  }
+
+  private async transcribeBusinessVoice(fileId: string): Promise<string> {
+    try {
+      const audioFilePath = await downloadFile(this.bot, fileId, LOCAL_FILES_PATH);
+      return await getTranscriptFromAudio(audioFilePath);
+    } catch (err) {
+      this.logger.error(`Failed to transcribe business voice: ${err}`);
+      return '';
+    }
+  }
+
+  private async checkInSendHandler(ctx: Context): Promise<void> {
+    if (!isOwner(ctx)) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    if (!OWNER_BUSINESS_CONNECTION_ID) {
+      await ctx.answerCallbackQuery({ text: 'Missing business connection id or target user id.', show_alert: true });
+      return;
+    }
+
+    try {
+      await this.bot.api.sendMessage(TOODIE_USER_ID, CHECK_IN_MESSAGE, { business_connection_id: OWNER_BUSINESS_CONNECTION_ID });
+      await ctx.editMessageText(`Sent ✅\n\n"${CHECK_IN_MESSAGE}"`);
+      await ctx.answerCallbackQuery({ text: 'Sent ✅' });
+    } catch (err) {
+      this.logger.error(`Failed to send check-in message: ${err}`);
+      await ctx.answerCallbackQuery({ text: 'Failed to send.', show_alert: true });
+    }
+  }
+
+  // One-tap execution of a suggested calendar/reminder action via the AI agent.
+  private async secretaryActionHandler(ctx: Context): Promise<void> {
+    if (!isOwner(ctx)) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    const data = ctx.callbackQuery?.data ?? '';
+    const shortId = data.slice(ACTION_CALLBACK_PREFIX.length);
+    const action = await getActionByShortId(shortId);
+
+    if (!action) {
+      await ctx.answerCallbackQuery({ text: 'Action not found.', show_alert: true });
+      return;
+    }
+    if (action.status === 'done') {
+      await ctx.answerCallbackQuery({ text: 'Already done ✅' });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({ text: 'Working… ⏳' });
+
+    const { ok, text } = await this.secretaryActionService.execute(action.instruction);
+    await updateActionStatus(shortId, ok ? 'done' : 'failed', text);
+
+    if (action.messageId) {
+      try {
+        const refreshed = await getActionsByMessageId(action.messageId);
+        await ctx.editMessageReplyMarkup({ reply_markup: buildActionsKeyboard(refreshed) });
+      } catch (err) {
+        this.logger.error(`Failed to refresh action keyboard: ${err}`);
+      }
+    }
+
+    await ctx.reply(`${ok ? '✅' : '❌'} ${text}`);
   }
 
   private async callbackQueryHandler(ctx: Context): Promise<void> {

--- a/src/features/chatbot/chatbot.init.ts
+++ b/src/features/chatbot/chatbot.init.ts
@@ -24,6 +24,7 @@ import { ChatbotSchedulerService } from './chatbot-scheduler.service';
 import { BOT_CONFIG } from './chatbot.config';
 import { ChatbotController } from './chatbot.controller';
 import { ChatbotService } from './chatbot.service';
+import { DB_NAME as SECRETARY_DB_NAME, ensureSecretaryMessageIndexes, SecretaryActionService, SecretaryMessageService } from './secretary';
 
 const logger = new Logger('initChatbot');
 
@@ -42,11 +43,13 @@ export async function initChatbot(app: Express): Promise<void> {
     FRIENDS_DB_NAME,
     MEET_FRIENDS_DB_NAME,
     USAGE_DB_NAME,
+    SECRETARY_DB_NAME,
   ];
   await Promise.all([...mongoDbNames.map(async (mongoDbName) => createMongoConnection(mongoDbName))]);
 
   await ensureUsageIndexes();
   await ensureReminderIndexes();
+  await ensureSecretaryMessageIndexes();
 
   // Build the checkpointer BEFORE provideTelegramBot(), which calls bot.start().
   // grammY locks the bot against new listeners once polling begins, so any `await`
@@ -57,8 +60,10 @@ export async function initChatbot(app: Express): Promise<void> {
   const bot = provideTelegramBot(BOT_CONFIG);
 
   const chatbotService = new ChatbotService(checkpointer);
-  const chatbotController = new ChatbotController(chatbotService, bot);
-  const chatbotScheduler = new ChatbotSchedulerService(chatbotService, bot);
+  const secretaryMessageService = new SecretaryMessageService();
+  const secretaryActionService = new SecretaryActionService();
+  const chatbotController = new ChatbotController(chatbotService, bot, secretaryMessageService, secretaryActionService);
+  const chatbotScheduler = new ChatbotSchedulerService(chatbotService, bot, secretaryMessageService);
 
   chatbotController.init();
   chatbotScheduler.init();

--- a/src/features/chatbot/schedulers/index.ts
+++ b/src/features/chatbot/schedulers/index.ts
@@ -25,3 +25,5 @@ export { spotifyPodcastUpdate } from './spotify-podcast-update';
 export { rainRadarAlert } from './rain-radar-alert';
 export { upcomingEventAlert } from './upcoming-event-alert';
 export { usageSummary } from './usage-summary';
+export { secretaryDailyDigest } from './secretary-daily-digest';
+export { secretaryCheckIn } from './secretary-check-in';

--- a/src/features/chatbot/schedulers/secretary-check-in.ts
+++ b/src/features/chatbot/schedulers/secretary-check-in.ts
@@ -1,0 +1,20 @@
+import type { Bot } from 'grammy';
+import { MY_USER_ID, TOODIE_USER_ID } from '@core/config';
+import { Logger } from '@core/utils';
+import { buildInlineKeyboard } from '@services/telegram';
+import { CHECK_IN_MESSAGE, CHECK_IN_SEND_CALLBACK, type SecretaryMessageService } from '../secretary';
+
+const logger = new Logger('SecretaryCheckIn');
+
+export async function secretaryCheckIn(bot: Bot, messageService: SecretaryMessageService): Promise<void> {
+  try {
+    if (await messageService.hasSpokenWithChatToday(TOODIE_USER_ID)) {
+      logger.log('Skipping check-in prompt: already spoke today.');
+      return;
+    }
+    const keyboard = buildInlineKeyboard([{ text: 'Send ✅', data: CHECK_IN_SEND_CALLBACK, style: 'success' }]);
+    await bot.api.sendMessage(MY_USER_ID, `Send this to her?\n\n"${CHECK_IN_MESSAGE}"`, { reply_markup: keyboard });
+  } catch (err) {
+    logger.error(`Failed to send check-in prompt: ${err}`);
+  }
+}

--- a/src/features/chatbot/schedulers/secretary-daily-digest.ts
+++ b/src/features/chatbot/schedulers/secretary-daily-digest.ts
@@ -1,0 +1,40 @@
+import type { Bot } from 'grammy';
+import { randomUUID } from 'node:crypto';
+import { MY_USER_ID } from '@core/config';
+import { Logger } from '@core/utils';
+import { sendShortenedMessage } from '@services/telegram';
+import { buildActionsKeyboard, createActions, type CreateSecretaryActionData, type SecretaryMessageService, type SecretarySummaryAction, setActionsMessageId } from '../secretary';
+
+const logger = new Logger('SecretaryDailyDigest');
+
+// Send a summary; when it has actionable items, attach one-tap buttons backed by persisted actions.
+async function sendSummaryWithActions(bot: Bot, summary: string, actions: SecretarySummaryAction[]): Promise<void> {
+  if (actions.length === 0) {
+    await sendShortenedMessage(bot, MY_USER_ID, summary);
+    return;
+  }
+
+  const records: CreateSecretaryActionData[] = actions.map((action) => ({ ...action, shortId: randomUUID().replace(/-/g, '').slice(0, 10), ownerChatId: MY_USER_ID }));
+  await createActions(records);
+
+  const keyboard = buildActionsKeyboard(records.map((record) => ({ shortId: record.shortId, label: record.label, status: 'pending' as const })));
+  const sent = await bot.api.sendMessage(MY_USER_ID, summary, { reply_markup: keyboard });
+  await setActionsMessageId(
+    records.map((record) => record.shortId),
+    sent.message_id,
+  );
+}
+
+export async function secretaryDailyDigest(bot: Bot, messageService: SecretaryMessageService): Promise<void> {
+  const cutoff = new Date();
+  try {
+    const summaries = await messageService.buildDailySummaries();
+    for (const { summary, actions } of summaries) {
+      await sendSummaryWithActions(bot, summary, actions);
+    }
+    const deleted = await messageService.clearMessagesBefore(cutoff);
+    logger.log(`Sent ${summaries.length} daily summaries, cleared ${deleted} messages.`);
+  } catch (err) {
+    logger.error(`Failed to send daily summaries: ${err}`);
+  }
+}

--- a/src/features/chatbot/secretary/index.ts
+++ b/src/features/chatbot/secretary/index.ts
@@ -1,0 +1,4 @@
+export * from './secretary.config';
+export * from './mongo';
+export { SecretaryMessageService, type DailySummary } from './secretary-message.service';
+export { SecretaryActionService, buildActionsKeyboard, type ActionResult } from './secretary-action.service';

--- a/src/features/chatbot/secretary/mongo/action.repository.ts
+++ b/src/features/chatbot/secretary/mongo/action.repository.ts
@@ -1,0 +1,29 @@
+import { getMongoCollection } from '@core/mongo';
+import { ACTIONS_COLLECTION, DB_NAME } from './constants';
+import type { CreateSecretaryActionData, SecretaryAction, SecretaryActionStatus } from './types';
+
+const getCollection = () => getMongoCollection<SecretaryAction>(DB_NAME, ACTIONS_COLLECTION);
+
+export async function createActions(data: CreateSecretaryActionData[]): Promise<void> {
+  if (data.length === 0) return;
+  const now = new Date();
+  const docs = data.map((d) => ({ ...d, status: 'pending', createdAt: now })) as SecretaryAction[];
+  await getCollection().insertMany(docs);
+}
+
+export async function getActionByShortId(shortId: string): Promise<SecretaryAction | null> {
+  return getCollection().findOne({ shortId });
+}
+
+export async function getActionsByMessageId(messageId: number): Promise<SecretaryAction[]> {
+  return getCollection().find({ messageId }).toArray();
+}
+
+export async function setActionsMessageId(shortIds: string[], messageId: number): Promise<void> {
+  if (shortIds.length === 0) return;
+  await getCollection().updateMany({ shortId: { $in: shortIds } }, { $set: { messageId } });
+}
+
+export async function updateActionStatus(shortId: string, status: SecretaryActionStatus, result: string): Promise<void> {
+  await getCollection().updateOne({ shortId }, { $set: { status, result, executedAt: new Date() } });
+}

--- a/src/features/chatbot/secretary/mongo/constants.ts
+++ b/src/features/chatbot/secretary/mongo/constants.ts
@@ -1,0 +1,5 @@
+export const DB_NAME = 'Secretary';
+
+export const MESSAGES_COLLECTION = 'Messages';
+
+export const ACTIONS_COLLECTION = 'Actions';

--- a/src/features/chatbot/secretary/mongo/index.ts
+++ b/src/features/chatbot/secretary/mongo/index.ts
@@ -1,0 +1,4 @@
+export { DB_NAME, MESSAGES_COLLECTION, ACTIONS_COLLECTION } from './constants';
+export type { SecretaryMessage, CreateSecretaryMessageData, SecretaryAction, CreateSecretaryActionData, SecretaryActionType, SecretaryActionStatus, SecretarySummaryAction } from './types';
+export { saveMessage, getMessagesForChatBetween, deleteMessagesBefore, ensureSecretaryMessageIndexes } from './message.repository';
+export { createActions, getActionByShortId, getActionsByMessageId, setActionsMessageId, updateActionStatus } from './action.repository';

--- a/src/features/chatbot/secretary/mongo/message.repository.ts
+++ b/src/features/chatbot/secretary/mongo/message.repository.ts
@@ -1,0 +1,29 @@
+import type { InsertOneResult } from 'mongodb';
+import { getMongoCollection } from '@core/mongo';
+import { DB_NAME, MESSAGES_COLLECTION } from './constants';
+import type { CreateSecretaryMessageData, SecretaryMessage } from './types';
+
+const getCollection = () => getMongoCollection<SecretaryMessage>(DB_NAME, MESSAGES_COLLECTION);
+
+export async function ensureSecretaryMessageIndexes(): Promise<void> {
+  const collection = getCollection();
+  await collection.createIndex({ chatId: 1, createdAt: -1 });
+  await collection.createIndex({ createdAt: 1 });
+}
+
+export async function saveMessage(data: CreateSecretaryMessageData): Promise<InsertOneResult<SecretaryMessage>> {
+  const message: Omit<SecretaryMessage, '_id'> = { ...data, createdAt: new Date() };
+  return getCollection().insertOne(message as SecretaryMessage);
+}
+
+export async function getMessagesForChatBetween(chatId: number, from: Date, to: Date): Promise<SecretaryMessage[]> {
+  return getCollection()
+    .find({ chatId, createdAt: { $gte: from, $lt: to } })
+    .sort({ createdAt: 1 })
+    .toArray();
+}
+
+export async function deleteMessagesBefore(cutoff: Date): Promise<number> {
+  const result = await getCollection().deleteMany({ createdAt: { $lt: cutoff } });
+  return result.deletedCount ?? 0;
+}

--- a/src/features/chatbot/secretary/mongo/types.ts
+++ b/src/features/chatbot/secretary/mongo/types.ts
@@ -1,0 +1,44 @@
+import type { ObjectId } from 'mongodb';
+
+export type SecretaryMessage = {
+  readonly _id?: ObjectId;
+  readonly chatId: number;
+  readonly fromOwner: boolean;
+  readonly senderName?: string;
+  readonly senderUsername?: string;
+  readonly text: string;
+  readonly transcribed: boolean;
+  readonly createdAt: Date;
+};
+
+export type CreateSecretaryMessageData = Omit<SecretaryMessage, '_id' | 'createdAt'>;
+
+export type SecretaryActionType = 'calendar' | 'reminder';
+
+export type SecretaryActionStatus = 'pending' | 'done' | 'failed';
+
+// A concrete, one-tap action extracted from a daily summary (calendar event or reminder).
+export type SecretarySummaryAction = {
+  readonly type: SecretaryActionType;
+  readonly label: string; // short button label in the conversation language, with a leading emoji
+  readonly instruction: string; // precise imperative for the agent, with absolute date and time
+};
+
+export type SecretaryAction = {
+  readonly _id?: ObjectId;
+  readonly shortId: string; // carried in callback_data
+  readonly ownerChatId: number;
+  readonly type: SecretaryActionType;
+  readonly label: string;
+  readonly instruction: string;
+  readonly status: SecretaryActionStatus;
+  readonly messageId?: number; // the summary message the button lives on
+  readonly result?: string;
+  readonly createdAt: Date;
+  readonly executedAt?: Date;
+};
+
+export type CreateSecretaryActionData = SecretarySummaryAction & {
+  readonly shortId: string;
+  readonly ownerChatId: number;
+};

--- a/src/features/chatbot/secretary/secretary-action.service.ts
+++ b/src/features/chatbot/secretary/secretary-action.service.ts
@@ -1,0 +1,59 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
+import type { InlineKeyboard } from 'grammy';
+import { createAgent } from 'langchain';
+import { env } from 'node:process';
+import { Logger } from '@core/utils';
+import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
+import { buildInlineKeyboard } from '@services/telegram';
+import { calendarTool, recordModelUsage, reminderTool, UsageCallbackHandler } from '@shared/ai';
+import type { SecretaryAction } from './mongo';
+import { ACTION_AGENT_PROMPT, ACTION_CALLBACK_PREFIX } from './secretary.config';
+
+export type ActionResult = {
+  readonly ok: boolean;
+  readonly text: string;
+};
+
+// Render the action buttons for a summary message, reflecting each action's current status.
+export function buildActionsKeyboard(actions: ReadonlyArray<Pick<SecretaryAction, 'shortId' | 'label' | 'status'>>): InlineKeyboard {
+  return buildInlineKeyboard(
+    actions.map((action) => ({
+      text: `${action.status === 'done' ? '✅ ' : action.status === 'failed' ? '❌ ' : ''}${action.label}`,
+      data: `${ACTION_CALLBACK_PREFIX}${action.shortId}`,
+    })),
+  );
+}
+
+export class SecretaryActionService {
+  private readonly logger = new Logger(SecretaryActionService.name);
+  private readonly agent: any;
+
+  constructor() {
+    const model = new ChatOpenAI({ model: CHAT_COMPLETIONS_MINI_MODEL, temperature: 0, apiKey: env.OPENAI_API_KEY, timeout: 120_000 });
+    const reactAgent = createAgent({ model, tools: [calendarTool, reminderTool], systemPrompt: ACTION_AGENT_PROMPT });
+    this.agent = reactAgent.graph;
+  }
+
+  // Run a single natural-language instruction through the agent and report success + a confirmation line.
+  async execute(instruction: string): Promise<ActionResult> {
+    try {
+      const usageHandler = new UsageCallbackHandler();
+      const startedAt = Date.now();
+      const result = await this.agent.invoke({ messages: [new HumanMessage(instruction)] }, { recursionLimit: 25, callbacks: [usageHandler] });
+      recordModelUsage({ source: 'chatbot-secretary', handler: usageHandler, durationMs: Date.now() - startedAt });
+      const messages: any[] = result?.messages ?? [];
+
+      const toolMessages = messages.filter((m) => m?._getType?.() === 'tool');
+      const anyFailure = toolMessages.some((m) => typeof m.content === 'string' && m.content.includes('"success":false'));
+      const lastAi = [...messages].reverse().find((m) => m?._getType?.() === 'ai');
+      const text = (typeof lastAi?.content === 'string' ? lastAi.content : '').trim() || 'Done.';
+
+      const ok = toolMessages.length > 0 && !anyFailure;
+      return { ok, text: ok ? text : text || 'The action could not be completed.' };
+    } catch (err) {
+      this.logger.error(`Action execution failed: ${err}`);
+      return { ok: false, text: `Failed to perform the action: ${err}` };
+    }
+  }
+}

--- a/src/features/chatbot/secretary/secretary-message.service.ts
+++ b/src/features/chatbot/secretary/secretary-message.service.ts
@@ -1,0 +1,103 @@
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from '@langchain/openai';
+import { endOfDay, format, startOfDay } from 'date-fns';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+import { env } from 'node:process';
+import { z } from 'zod';
+import { DEFAULT_TIMEZONE, TOODIE_USER_ID } from '@core/config';
+import { Logger } from '@core/utils';
+import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
+import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
+import { deleteMessagesBefore, getMessagesForChatBetween, saveMessage, type SecretaryMessage, type SecretarySummaryAction } from './mongo';
+import { OWNER_NAME, SUMMARY_PROMPT } from './secretary.config';
+
+const summarySchema = z.object({
+  summary: z.string().describe('The prose end-of-day briefing for this chat'),
+  actions: z
+    .array(
+      z.object({
+        type: z.enum(['calendar', 'reminder']).describe('The kind of action'),
+        label: z.string().describe('Short button label in the conversation language, starting with an emoji (📅 calendar, ⏰ reminder)'),
+        instruction: z.string().describe('Precise imperative for an assistant to execute, with absolute date and time'),
+      }),
+    )
+    .describe('Concrete one-tap calendar/reminder actions grounded in the conversation; empty if none'),
+});
+
+export type DailySummary = {
+  readonly chatId: number;
+  readonly summary: string;
+  readonly actions: SecretarySummaryAction[];
+};
+
+// Build the day window [00:00, next 00:00) in the project timezone.
+const todayWindow = () => {
+  const nowLocal = toZonedTime(new Date(), DEFAULT_TIMEZONE);
+  const start = fromZonedTime(startOfDay(nowLocal), DEFAULT_TIMEZONE);
+  const end = fromZonedTime(endOfDay(nowLocal), DEFAULT_TIMEZONE);
+  return { start, end };
+};
+
+export class SecretaryMessageService {
+  private readonly logger = new Logger(SecretaryMessageService.name);
+  private readonly model: ChatOpenAI;
+
+  constructor() {
+    this.model = new ChatOpenAI({ model: CHAT_COMPLETIONS_MINI_MODEL, temperature: 0.4, apiKey: env.OPENAI_API_KEY, timeout: 120_000 });
+  }
+
+  // Persist a single message (either side) for later daily summarization.
+  async storeMessage(data: { chatId: number; fromOwner: boolean; text: string; transcribed?: boolean; senderName?: string; senderUsername?: string }): Promise<void> {
+    const { chatId, fromOwner, text, transcribed = false, senderName, senderUsername } = data;
+    await saveMessage({ chatId, fromOwner, text, transcribed, senderName, senderUsername });
+  }
+
+  // Delete persisted messages older than the cutoff, after the daily summaries have been sent.
+  async clearMessagesBefore(cutoff: Date): Promise<number> {
+    return deleteMessagesBefore(cutoff);
+  }
+
+  // Whether there was any conversation with the given chat today (project timezone).
+  async hasSpokenWithChatToday(chatId: number): Promise<boolean> {
+    const { start, end } = todayWindow();
+    const messages = await getMessagesForChatBetween(chatId, start, end);
+    return messages.length > 0;
+  }
+
+  // Generate and return one summary (with extracted actions) per chat that had activity today.
+  async buildDailySummaries(): Promise<DailySummary[]> {
+    const { start, end } = todayWindow();
+
+    const summaries: DailySummary[] = [];
+    const chatId = TOODIE_USER_ID;
+    const messages = await getMessagesForChatBetween(chatId, start, end);
+    if (messages.length === 0) return summaries;
+    const result = await this.summarizeChat(messages);
+    if (result) summaries.push({ chatId, ...result });
+    return summaries;
+  }
+
+  private async summarizeChat(messages: SecretaryMessage[]): Promise<{ summary: string; actions: SecretarySummaryAction[] } | null> {
+    try {
+      const other = messages.find((m) => !m.fromOwner);
+      const otherName = other?.senderName || other?.senderUsername || `chat ${messages[0].chatId}`;
+      const dateStr = format(toZonedTime(new Date(), DEFAULT_TIMEZONE), 'dd/MM/yyyy');
+
+      const transcript = messages.map((m) => `${m.fromOwner ? OWNER_NAME : otherName}: ${m.text}`).join('\n');
+      const userPrompt = `Conversation with ${otherName} on ${dateStr} (use this date to resolve relative dates):\n\n${transcript}`;
+
+      const structured = this.model.withStructuredOutput(summarySchema, { name: 'daily_summary' });
+      const usageHandler = new UsageCallbackHandler();
+      const startedAt = Date.now();
+      const result = await structured.invoke([new SystemMessage(SUMMARY_PROMPT), new HumanMessage(userPrompt)], { callbacks: [usageHandler] });
+      recordModelUsage({ source: 'chatbot-secretary', chatId: messages[0]?.chatId, handler: usageHandler, durationMs: Date.now() - startedAt });
+
+      const body = result.summary.trim();
+      const summary = `🗒️ Daily summary — ${otherName} (${dateStr})\n\n${body}`;
+      return { summary, actions: (result.actions ?? []) as SecretarySummaryAction[] };
+    } catch (err) {
+      this.logger.error(`Failed to summarize chat ${messages[0]?.chatId}: ${err}`);
+      return null;
+    }
+  }
+}

--- a/src/features/chatbot/secretary/secretary.config.ts
+++ b/src/features/chatbot/secretary/secretary.config.ts
@@ -1,0 +1,37 @@
+import { env } from 'node:process';
+import { DEFAULT_TIMEZONE } from '@core/config';
+
+export const OWNER_NAME = 'Guz | (hebrew: גוז)';
+
+export const TRANSCRIPTION_HEADER = 'Message transcription:';
+
+// Check-in feature: ask the owner to approve sending a fixed message to a chat on Mon/Tue/Wed.
+export const OWNER_BUSINESS_CONNECTION_ID = env.OWNER_BUSINESS_CONNECTION_ID;
+export const CHECK_IN_MESSAGE = 'מה קורה חיים?  איך את??';
+export const CHECK_IN_SEND_CALLBACK = 'check_in:send';
+
+// Callback prefix for one-tap action buttons rendered under daily summaries.
+export const ACTION_CALLBACK_PREFIX = 'sec:act:';
+
+export const SUMMARY_PROMPT = `You are a personal assistant for ${OWNER_NAME}. You are given the full text of a one-day private Telegram conversation between ${OWNER_NAME} ("me"/owner) and another person.
+
+Your job is to help ${OWNER_NAME} by producing two things:
+
+1. "summary": a short end-of-day briefing for this single chat:
+   - A concise summary of what was discussed today (2-4 sentences).
+   - Actionable suggestions ${OWNER_NAME} can act on (calendar events, reminders, follow-ups/replies owed, things promised or not to forget).
+
+2. "actions": a list of concrete, one-tap actions extracted from the conversation — ONLY calendar events to create or reminders to set, and ONLY when clearly grounded in what was actually said. For each action provide:
+   - "type": "calendar" or "reminder".
+   - "label": a short button label (max ~40 chars) in the conversation's language, starting with an emoji (📅 for calendar, ⏰ for reminder), e.g. "📅 רופא שיניים חמישי 16:00".
+   - "instruction": a precise, self-contained imperative for an assistant to execute, with an ABSOLUTE date and time (resolve "tomorrow"/"Thursday" using the conversation date provided in the prompt), e.g. "Create a calendar event 'Dentist' on 2026-06-25 at 16:00".
+
+Rules:
+- Only ground actions and suggestions in the actual conversation. Never invent commitments, dates, or details.
+- If there is nothing worth acting on, the "summary" should say so briefly and "actions" must be an empty array.
+- Do not duplicate the same action.
+- Reply in the language used in the conversation (Hebrew or English).
+- Keep the summary tight and skimmable. Plain text, light emojis are fine, no heavy markdown.`;
+
+// Prompt for the agent that executes a single tapped action via its calendar/reminder tools.
+export const ACTION_AGENT_PROMPT = `You are an execution assistant for ${OWNER_NAME}. You receive a single instruction describing exactly one action to perform — either creating a Google Calendar event or creating a reminder. Use the available tools to perform exactly that action, resolving any dates and times in the ${DEFAULT_TIMEZONE} timezone. Do not ask follow-up questions; act on the instruction as given. After performing the action, reply with one short confirmation sentence in the same language as the instruction, stating what was created including the date and time.`;

--- a/test/e2e/chatbot.controller.e2e.spec.ts
+++ b/test/e2e/chatbot.controller.e2e.spec.ts
@@ -12,7 +12,9 @@ describe('ChatbotController E2E', () => {
     testBot = createTestBot(BOT_CONFIG);
     processMessage = vi.fn().mockResolvedValue({ message: 'stub reply', toolResults: [] });
     const chatbotService = { processMessage } as any;
-    const controller = new ChatbotController(chatbotService, testBot.bot);
+    const secretaryMessageService = { storeMessage: vi.fn(), hasSpokenWithChatToday: vi.fn(), buildDailySummaries: vi.fn(), clearMessagesBefore: vi.fn() } as any;
+    const secretaryActionService = { execute: vi.fn() } as any;
+    const controller = new ChatbotController(chatbotService, testBot.bot, secretaryMessageService, secretaryActionService);
     controller.init();
   });
 


### PR DESCRIPTION
## Why

We want to retire the standalone Secretary bot and have the Chatbot own its useful behavior. This PR is the first step: it duplicates the features we want to keep into the Chatbot feature so the Chatbot can take over the Telegram Business flow, while the Secretary bot stays fully intact and running.

## Approach

Rather than move or refactor Secretary code, this adds a self-contained copy under `src/features/chatbot/secretary/` that reuses the **same** `Secretary` MongoDB database (`Messages` / `Actions` collections). Both systems can run side by side against the same data, so the eventual cutover is just a Telegram-side switch plus an env var, with no data migration.

What was duplicated:
- **Message logging** into `Secretary.Messages` for the owner's business chats.
- **Daily summary + one-tap actions** (`30 23` cron): builds per-chat summaries, sends them as a DM with calendar/reminder action buttons, then clears old messages. Tapping a button runs the action agent and updates the button state.
- **Check-in prompt** (`13 11 * * 1,2,3` cron): DMs a check-in prompt when the owner hasn't spoken that day; the Send button delivers the message via the business connection.
- **Business-chat voice**: transcribed (either sender), echoed back into the chat, and stored with `transcribed: true`.

Wiring is additive only: the chatbot controller gains two constructor params and handlers for `business_connection`, `business_message`, `check_in:send`, and `sec:act:` callbacks; the init and scheduler register the new DB/services/crons.

## Intentionally NOT moved

- DM voice transcription (the Chatbot keeps its own audio handler).
- Smart reply drafts.
- Forgotten-reply nudges.

## Notes for reviewers

- Callback prefixes (`sec:act:`, `check_in:send`) don't collide with existing chatbot callbacks, so registering them separately is safe.
- Usage metering for the copied services is tagged `source: 'chatbot-secretary'`.
- The business handlers stay dormant until the Telegram Business connection is re-pointed from the Secretary bot to the Chatbot bot. That is a manual Telegram-app + env (`OWNER_BUSINESS_CONNECTION_ID`) change and cannot be done in code; a step-by-step guide was produced separately in the session.

## Validation

- `npm run typecheck` - 0 errors.
- `eslint` on changed files - 0 errors (only pre-existing `any` warnings, consistent with existing style).
- Chatbot e2e suite - 3/3 pass.
