### PR TITLE
refactor(logging): standardize log format and remove duplication

### DIFF
--- a/src/core/mongo/user.repository.ts
+++ b/src/core/mongo/user.repository.ts
@@ -20,7 +20,7 @@ export function createUserRepository(dbName: string) {
       await userCollection.insertOne(user);
       return false;
     } catch (err) {
-      logger.error(`saveUserDetails - err: ${err}`);
+      logger.error(`saveUserDetails - err: ${err instanceof Error ? err.message : String(err)}`);
       return false;
     }
   }
@@ -30,7 +30,7 @@ export function createUserRepository(dbName: string) {
       const userCollection = getCollection();
       return userCollection.findOne({ chatId });
     } catch (err) {
-      logger.error(`getUserDetails - err: ${err}`);
+      logger.error(`getUserDetails - err: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     }
   }

--- a/src/core/mongo/user.repository.ts
+++ b/src/core/mongo/user.repository.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getMongoCollection } from './mongo-connection';
 import type { User } from './types';
 
@@ -20,7 +20,7 @@ export function createUserRepository(dbName: string) {
       await userCollection.insertOne(user);
       return false;
     } catch (err) {
-      logger.error(`saveUserDetails - err: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`saveUserDetails - err: ${getErrorMessage(err)}`);
       return false;
     }
   }
@@ -30,7 +30,7 @@ export function createUserRepository(dbName: string) {
       const userCollection = getCollection();
       return userCollection.findOne({ chatId });
     } catch (err) {
-      logger.error(`getUserDetails - err: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`getUserDetails - err: ${getErrorMessage(err)}`);
       return null;
     }
   }

--- a/src/core/queue/base-worker.ts
+++ b/src/core/queue/base-worker.ts
@@ -1,6 +1,6 @@
 import { Worker } from 'bullmq';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import type { BaseJobData, WorkerConfig } from './types';
 
 const DEFAULT_CONCURRENCY = 10;
@@ -29,7 +29,7 @@ export function createWorker<T extends BaseJobData>(config: WorkerConfig<T>): Wo
   });
 
   worker.on('failed', (job, err) => {
-    logger.error(`Job ${job?.id} failed: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Job ${job?.id} failed: ${getErrorMessage(err)}`);
     if (config.onFailed) {
       config.onFailed(job, err);
     }

--- a/src/core/queue/base-worker.ts
+++ b/src/core/queue/base-worker.ts
@@ -29,7 +29,7 @@ export function createWorker<T extends BaseJobData>(config: WorkerConfig<T>): Wo
   });
 
   worker.on('failed', (job, err) => {
-    logger.error(`Job ${job?.id} failed: ${err.message}`);
+    logger.error(`Job ${job?.id} failed: ${err instanceof Error ? err.message : String(err)}`);
     if (config.onFailed) {
       config.onFailed(job, err);
     }

--- a/src/core/utils/get-error-message.spec.ts
+++ b/src/core/utils/get-error-message.spec.ts
@@ -1,0 +1,24 @@
+import { getErrorMessage } from './get-error-message';
+
+describe('getErrorMessage()', () => {
+  it('should return the message when given an Error', () => {
+    expect(getErrorMessage(new Error('boom'))).toEqual('boom');
+  });
+
+  it('should return the message for Error subclasses', () => {
+    expect(getErrorMessage(new TypeError('bad type'))).toEqual('bad type');
+  });
+
+  it('should stringify a non-Error value', () => {
+    expect(getErrorMessage('just a string')).toEqual('just a string');
+  });
+
+  it('should stringify a number', () => {
+    expect(getErrorMessage(42)).toEqual('42');
+  });
+
+  it('should stringify null and undefined', () => {
+    expect(getErrorMessage(null)).toEqual('null');
+    expect(getErrorMessage(undefined)).toEqual('undefined');
+  });
+});

--- a/src/core/utils/get-error-message.ts
+++ b/src/core/utils/get-error-message.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/core/utils/graceful-shutdown.ts
+++ b/src/core/utils/graceful-shutdown.ts
@@ -1,4 +1,5 @@
 import { exit } from 'node:process';
+import { getErrorMessage } from '@core/utils';
 import { Logger } from './logger';
 
 let shuttingDown = false;
@@ -10,7 +11,7 @@ const shutdown = (logger: Logger, reason: string, err: unknown, close: () => Pro
   if (exitCode === 0) {
     logger.log(`Shutting down gracefully on '${reason}'`);
   } else {
-    logger.error(`Unhandled failure by '${reason}'! ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Unhandled failure by '${reason}'! ${getErrorMessage(err)}`);
   }
 
   const timer = setTimeout(() => {
@@ -32,7 +33,7 @@ export function gracefulShutdown(...closes: (() => Promise<unknown> | unknown)[]
       try {
         await fn();
       } catch (err) {
-        logger.error(`An error occurred during graceful shutdown! ${err instanceof Error ? err.message : String(err)}`);
+        logger.error(`An error occurred during graceful shutdown! ${getErrorMessage(err)}`);
       }
     }
   };

--- a/src/core/utils/graceful-shutdown.ts
+++ b/src/core/utils/graceful-shutdown.ts
@@ -10,7 +10,7 @@ const shutdown = (logger: Logger, reason: string, err: unknown, close: () => Pro
   if (exitCode === 0) {
     logger.log(`Shutting down gracefully on '${reason}'`);
   } else {
-    logger.error(`Unhandled failure by '${reason}'! ${err}`);
+    logger.error(`Unhandled failure by '${reason}'! ${err instanceof Error ? err.message : String(err)}`);
   }
 
   const timer = setTimeout(() => {
@@ -32,7 +32,7 @@ export function gracefulShutdown(...closes: (() => Promise<unknown> | unknown)[]
       try {
         await fn();
       } catch (err) {
-        logger.error(`An error occurred during graceful shutdown! ${err}`);
+        logger.error(`An error occurred during graceful shutdown! ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   };

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -4,6 +4,7 @@ export { deleteFile } from './delete-file';
 export { extractAudioFromVideo } from './extract-audio-from-video';
 export { formatNumber } from './format-number';
 export { generateRandomString } from './generate-random-string';
+export { getErrorMessage } from './get-error-message';
 export { getDateDescription } from './get-date-description';
 export { getDateNumber } from './get-date-number';
 export { getDateString } from './get-date-string';

--- a/src/core/utils/set-ffmpeg-path.ts
+++ b/src/core/utils/set-ffmpeg-path.ts
@@ -6,7 +6,7 @@ export function setFfmpegPath() {
   const logger = new Logger(setFfmpegPath.name);
   exec('which ffmpeg', (err, stdout: string) => {
     if (err) {
-      logger.error(`which ffmpeg exec - Error finding ffmpeg: ${err}`);
+      logger.error(`which ffmpeg exec - Error finding ffmpeg: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
     logger.log(`which ffmpeg exec - ffmpeg path: ${stdout.trim()}`);

--- a/src/core/utils/set-ffmpeg-path.ts
+++ b/src/core/utils/set-ffmpeg-path.ts
@@ -1,12 +1,12 @@
 import { exec } from 'child_process';
 import ffmpeg from 'fluent-ffmpeg';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 export function setFfmpegPath() {
   const logger = new Logger(setFfmpegPath.name);
   exec('which ffmpeg', (err, stdout: string) => {
     if (err) {
-      logger.error(`which ffmpeg exec - Error finding ffmpeg: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`which ffmpeg exec - Error finding ffmpeg: ${getErrorMessage(err)}`);
       return;
     }
     logger.log(`which ffmpeg exec - ffmpeg path: ${stdout.trim()}`);

--- a/src/features/chatbot/agent/checkpointer.ts
+++ b/src/features/chatbot/agent/checkpointer.ts
@@ -17,7 +17,7 @@ export async function createChatbotCheckpointer(): Promise<MongoDBSaver> {
   const checkpointer = new MongoDBSaver({ client: client as never, dbName: CHECKPOINTS_DB_NAME, ttl: THIRTY_DAYS_IN_SECONDS });
 
   const errors = await checkpointer.setup();
-  errors.forEach((err) => logger.error(`checkpointer setup error: ${err.message}`));
+  errors.forEach((err) => logger.error(`checkpointer setup error: ${err instanceof Error ? err.message : String(err)}`));
 
   logger.log(`Chatbot checkpointer ready (db: ${CHECKPOINTS_DB_NAME}, ttl: ${THIRTY_DAYS_IN_SECONDS}s)`);
   return checkpointer;

--- a/src/features/chatbot/agent/checkpointer.ts
+++ b/src/features/chatbot/agent/checkpointer.ts
@@ -1,7 +1,7 @@
 import { MongoDBSaver } from '@langchain/langgraph-checkpoint-mongodb';
 import { MongoClient } from 'mongodb';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 const logger = new Logger('chatbot-checkpointer');
 
@@ -17,7 +17,7 @@ export async function createChatbotCheckpointer(): Promise<MongoDBSaver> {
   const checkpointer = new MongoDBSaver({ client: client as never, dbName: CHECKPOINTS_DB_NAME, ttl: THIRTY_DAYS_IN_SECONDS });
 
   const errors = await checkpointer.setup();
-  errors.forEach((err) => logger.error(`checkpointer setup error: ${err instanceof Error ? err.message : String(err)}`));
+  errors.forEach((err) => logger.error(`checkpointer setup error: ${getErrorMessage(err)}`));
 
   logger.log(`Chatbot checkpointer ready (db: ${CHECKPOINTS_DB_NAME}, ttl: ${THIRTY_DAYS_IN_SECONDS}s)`);
   return checkpointer;

--- a/src/features/chatbot/api/chatbot.api.controller.ts
+++ b/src/features/chatbot/api/chatbot.api.controller.ts
@@ -6,7 +6,7 @@ import { ObjectId } from 'mongodb';
 import { z } from 'zod';
 import { DEFAULT_TIMEZONE } from '@core/config';
 import { registry } from '@core/openapi';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { fetchEmailFull, fetchUserEmails, markEmailAsRead, trashEmail } from '@services/gmail';
 import { createEvent, deleteEvent, listEvents } from '@services/google-calendar';
 import type { CalendarEvent as GoogleCalendarEvent } from '@services/google-calendar';
@@ -318,7 +318,7 @@ async function fetchEventsForDate(date: Date): Promise<GoogleCalendarEvent[]> {
     const timeMax = addDays(date, 1).toISOString();
     return await listEvents({ timeMin, timeMax, singleEvents: true, orderBy: 'startTime', maxResults: 250 });
   } catch (err) {
-    logger.warn(`Failed to fetch calendar events for ${dateKey(date)}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.warn(`Failed to fetch calendar events for ${dateKey(date)}: ${getErrorMessage(err)}`);
     return [];
   }
 }
@@ -354,7 +354,7 @@ export function registerChatbotApiRoutes(app: Express): void {
         reminders: reminders.map(toReminderDto),
       });
     } catch (err) {
-      logger.error(`dashboard failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`dashboard failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'dashboard_failed' });
     }
   });
@@ -380,7 +380,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(201).json(toReminderDto(created));
     } catch (err) {
-      logger.error(`reminder create failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`reminder create failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -428,7 +428,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.json(toReminderDto(updated));
     } catch (err) {
-      logger.error(`reminder update failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`reminder update failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });
@@ -448,7 +448,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(204).end();
     } catch (err) {
-      logger.error(`reminder delete failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`reminder delete failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -474,7 +474,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       });
       res.status(201).json(toEventDto(created, 'event-created'));
     } catch (err) {
-      logger.error(`calendar event create failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`calendar event create failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -498,7 +498,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(204).end();
     } catch (err) {
-      logger.error(`calendar event delete failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`calendar event delete failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -540,7 +540,7 @@ export function registerChatbotApiRoutes(app: Express): void {
 
       res.json({ days, totals: { cost: totalCost, turns: totalTurns, tokensTotal: totalTokens }, perDay, perSource });
     } catch (err) {
-      logger.error(`usage failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`usage failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'usage_failed' });
     }
   });
@@ -550,7 +550,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       const emails = (await fetchUserEmails('is:unread in:inbox', 10)) ?? [];
       res.json({ emails });
     } catch (err) {
-      logger.error(`emails failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`emails failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'emails_failed' });
     }
   });
@@ -569,7 +569,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.json({ id: email.id, from: email.from, subject: email.subject, date: email.date, bodyText: email.bodyText });
     } catch (err) {
-      logger.error(`email fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`email fetch failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'emails_failed' });
     }
   });
@@ -584,7 +584,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       await markEmailAsRead(id);
       res.status(204).end();
     } catch (err) {
-      logger.error(`mark read failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`mark read failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'mark_read_failed' });
     }
   });
@@ -599,7 +599,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       await trashEmail(id);
       res.status(204).end();
     } catch (err) {
-      logger.error(`email delete failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`email delete failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -619,7 +619,7 @@ export function registerChatbotApiRoutes(app: Express): void {
         .sort((a, b) => a.date.localeCompare(b.date));
       res.json({ birthdays });
     } catch (err) {
-      logger.error(`birthdays failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`birthdays failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'birthdays_failed' });
     }
   });

--- a/src/features/chatbot/api/chatbot.api.controller.ts
+++ b/src/features/chatbot/api/chatbot.api.controller.ts
@@ -318,7 +318,7 @@ async function fetchEventsForDate(date: Date): Promise<GoogleCalendarEvent[]> {
     const timeMax = addDays(date, 1).toISOString();
     return await listEvents({ timeMin, timeMax, singleEvents: true, orderBy: 'startTime', maxResults: 250 });
   } catch (err) {
-    logger.warn(`Failed to fetch calendar events for ${dateKey(date)}: ${err}`);
+    logger.warn(`Failed to fetch calendar events for ${dateKey(date)}: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }
@@ -354,7 +354,7 @@ export function registerChatbotApiRoutes(app: Express): void {
         reminders: reminders.map(toReminderDto),
       });
     } catch (err) {
-      logger.error(`dashboard failed: ${err}`);
+      logger.error(`dashboard failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'dashboard_failed' });
     }
   });
@@ -380,7 +380,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(201).json(toReminderDto(created));
     } catch (err) {
-      logger.error(`reminder create failed: ${err}`);
+      logger.error(`reminder create failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -428,7 +428,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.json(toReminderDto(updated));
     } catch (err) {
-      logger.error(`reminder update failed: ${err}`);
+      logger.error(`reminder update failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });
@@ -448,7 +448,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(204).end();
     } catch (err) {
-      logger.error(`reminder delete failed: ${err}`);
+      logger.error(`reminder delete failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -474,7 +474,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       });
       res.status(201).json(toEventDto(created, 'event-created'));
     } catch (err) {
-      logger.error(`calendar event create failed: ${err}`);
+      logger.error(`calendar event create failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -498,7 +498,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.status(204).end();
     } catch (err) {
-      logger.error(`calendar event delete failed: ${err}`);
+      logger.error(`calendar event delete failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -540,7 +540,7 @@ export function registerChatbotApiRoutes(app: Express): void {
 
       res.json({ days, totals: { cost: totalCost, turns: totalTurns, tokensTotal: totalTokens }, perDay, perSource });
     } catch (err) {
-      logger.error(`usage failed: ${err}`);
+      logger.error(`usage failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'usage_failed' });
     }
   });
@@ -550,7 +550,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       const emails = (await fetchUserEmails('is:unread in:inbox', 10)) ?? [];
       res.json({ emails });
     } catch (err) {
-      logger.error(`emails failed: ${err}`);
+      logger.error(`emails failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'emails_failed' });
     }
   });
@@ -569,7 +569,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       }
       res.json({ id: email.id, from: email.from, subject: email.subject, date: email.date, bodyText: email.bodyText });
     } catch (err) {
-      logger.error(`email fetch failed: ${err}`);
+      logger.error(`email fetch failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'emails_failed' });
     }
   });
@@ -584,7 +584,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       await markEmailAsRead(id);
       res.status(204).end();
     } catch (err) {
-      logger.error(`mark read failed: ${err}`);
+      logger.error(`mark read failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'mark_read_failed' });
     }
   });
@@ -599,7 +599,7 @@ export function registerChatbotApiRoutes(app: Express): void {
       await trashEmail(id);
       res.status(204).end();
     } catch (err) {
-      logger.error(`email delete failed: ${err}`);
+      logger.error(`email delete failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'delete_failed' });
     }
   });
@@ -619,7 +619,7 @@ export function registerChatbotApiRoutes(app: Express): void {
         .sort((a, b) => a.date.localeCompare(b.date));
       res.json({ birthdays });
     } catch (err) {
-      logger.error(`birthdays failed: ${err}`);
+      logger.error(`birthdays failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'birthdays_failed' });
     }
   });

--- a/src/features/chatbot/chatbot-scheduler.service.ts
+++ b/src/features/chatbot/chatbot-scheduler.service.ts
@@ -30,7 +30,8 @@ import { LOOKBACK_MINUTES } from './schedulers/earthquake-monitor';
 const logger = new Logger('ChatbotScheduler');
 
 function createSchedule(expression: string, handler: () => Promise<void>, timezone: string = DEFAULT_TIMEZONE): void {
-  cron.schedule(expression, () => handler().catch((err) => logger.error(`Scheduled task failed: ${err}`)), { timezone });
+  const onError = (err: unknown) => logger.error(`Scheduled task failed: ${err instanceof Error ? err.message : String(err)}`);
+  cron.schedule(expression, () => handler().catch(onError), { timezone });
 }
 
 export class ChatbotSchedulerService {

--- a/src/features/chatbot/chatbot-scheduler.service.ts
+++ b/src/features/chatbot/chatbot-scheduler.service.ts
@@ -1,9 +1,8 @@
 import type { Bot } from 'grammy';
 import cron from 'node-cron';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { ChatbotService } from './chatbot.service';
-import type { SecretaryMessageService } from './secretary';
 import {
   birthdayReminder,
   dailySummary,
@@ -26,11 +25,12 @@ import {
   weeklyExerciseSummary,
 } from './schedulers';
 import { LOOKBACK_MINUTES } from './schedulers/earthquake-monitor';
+import type { SecretaryMessageService } from './secretary';
 
 const logger = new Logger('ChatbotScheduler');
 
 function createSchedule(expression: string, handler: () => Promise<void>, timezone: string = DEFAULT_TIMEZONE): void {
-  const onError = (err: unknown) => logger.error(`Scheduled task failed: ${err instanceof Error ? err.message : String(err)}`);
+  const onError = (err: unknown) => logger.error(`Scheduled task failed: ${getErrorMessage(err)}`);
   cron.schedule(expression, () => handler().catch(onError), { timezone });
 }
 

--- a/src/features/chatbot/chatbot.controller.ts
+++ b/src/features/chatbot/chatbot.controller.ts
@@ -2,7 +2,7 @@ import type { Bot, Context } from 'grammy';
 import type { ReactionTypeEmoji } from 'grammy/types';
 import { env } from 'node:process';
 import { LOCAL_FILES_PATH, MY_USER_ID, WIFE_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { deleteFile } from '@core/utils';
 import { imgurUploadImage } from '@services/imgur';
 import { analyzeImage } from '@services/openai/utils/analyze-image';
@@ -98,7 +98,7 @@ export class ChatbotController {
       const audioFilePath = await downloadFile(this.bot, fileId, LOCAL_FILES_PATH);
       return await getTranscriptFromAudio(audioFilePath);
     } catch (err) {
-      this.logger.error(`Failed to transcribe business voice: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to transcribe business voice: ${getErrorMessage(err)}`);
       return '';
     }
   }
@@ -119,7 +119,7 @@ export class ChatbotController {
       await ctx.editMessageText(`Sent ✅\n\n"${CHECK_IN_MESSAGE}"`);
       await ctx.answerCallbackQuery({ text: 'Sent ✅' });
     } catch (err) {
-      this.logger.error(`Failed to send check-in message: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to send check-in message: ${getErrorMessage(err)}`);
       await ctx.answerCallbackQuery({ text: 'Failed to send.', show_alert: true });
     }
   }
@@ -154,7 +154,7 @@ export class ChatbotController {
         const refreshed = await getActionsByMessageId(action.messageId);
         await ctx.editMessageReplyMarkup({ reply_markup: buildActionsKeyboard(refreshed) });
       } catch (err) {
-        this.logger.error(`Failed to refresh action keyboard: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.error(`Failed to refresh action keyboard: ${getErrorMessage(err)}`);
       }
     }
 
@@ -210,7 +210,7 @@ export class ChatbotController {
       await ctx.editMessageText(`😴 *Snoozed for ${label}*\n${reminder.message}`, { parse_mode: 'Markdown' }).catch(() => {});
       await ctx.answerCallbackQuery({ text: `Snoozed for ${label}` }).catch(() => {});
     } catch (err) {
-      this.logger.error(`Error handling reminder callback: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error handling reminder callback: ${getErrorMessage(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }
@@ -237,14 +237,14 @@ export class ChatbotController {
           break;
         case 'remind':
           setTimeout(() => {
-            sendExerciseReminder(this.bot, this.chatbotService).catch((err) => this.logger.error(`Failed to re-send exercise reminder: ${err instanceof Error ? err.message : String(err)}`));
+            sendExerciseReminder(this.bot, this.chatbotService).catch((err) => this.logger.error(`Failed to re-send exercise reminder: ${getErrorMessage(err)}`));
           }, EXERCISE_REMIND_DELAY_MS);
           await ctx.editMessageText('😴 Okay, I will remind you again in 1 hour.', { parse_mode: 'Markdown' }).catch(() => {});
           await ctx.answerCallbackQuery({ text: 'Reminding in 1 hour' }).catch(() => {});
           break;
       }
     } catch (err) {
-      this.logger.error(`Error handling exercise callback: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error handling exercise callback: ${getErrorMessage(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }
@@ -258,7 +258,7 @@ export class ChatbotController {
       const { message } = await this.chatbotService.processMessage(prompt, chatId);
       await sendRichMessage(this.bot, chatId, message);
     } catch (err) {
-      this.logger.error(`Error handling birthday callback: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error handling birthday callback: ${getErrorMessage(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }

--- a/src/features/chatbot/chatbot.controller.ts
+++ b/src/features/chatbot/chatbot.controller.ts
@@ -98,7 +98,7 @@ export class ChatbotController {
       const audioFilePath = await downloadFile(this.bot, fileId, LOCAL_FILES_PATH);
       return await getTranscriptFromAudio(audioFilePath);
     } catch (err) {
-      this.logger.error(`Failed to transcribe business voice: ${err}`);
+      this.logger.error(`Failed to transcribe business voice: ${err instanceof Error ? err.message : String(err)}`);
       return '';
     }
   }
@@ -119,7 +119,7 @@ export class ChatbotController {
       await ctx.editMessageText(`Sent ✅\n\n"${CHECK_IN_MESSAGE}"`);
       await ctx.answerCallbackQuery({ text: 'Sent ✅' });
     } catch (err) {
-      this.logger.error(`Failed to send check-in message: ${err}`);
+      this.logger.error(`Failed to send check-in message: ${err instanceof Error ? err.message : String(err)}`);
       await ctx.answerCallbackQuery({ text: 'Failed to send.', show_alert: true });
     }
   }
@@ -154,7 +154,7 @@ export class ChatbotController {
         const refreshed = await getActionsByMessageId(action.messageId);
         await ctx.editMessageReplyMarkup({ reply_markup: buildActionsKeyboard(refreshed) });
       } catch (err) {
-        this.logger.error(`Failed to refresh action keyboard: ${err}`);
+        this.logger.error(`Failed to refresh action keyboard: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 
@@ -210,7 +210,7 @@ export class ChatbotController {
       await ctx.editMessageText(`😴 *Snoozed for ${label}*\n${reminder.message}`, { parse_mode: 'Markdown' }).catch(() => {});
       await ctx.answerCallbackQuery({ text: `Snoozed for ${label}` }).catch(() => {});
     } catch (err) {
-      this.logger.error(`Error handling reminder callback: ${err}`);
+      this.logger.error(`Error handling reminder callback: ${err instanceof Error ? err.message : String(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }
@@ -237,14 +237,14 @@ export class ChatbotController {
           break;
         case 'remind':
           setTimeout(() => {
-            sendExerciseReminder(this.bot, this.chatbotService).catch((err) => this.logger.error(`Failed to re-send exercise reminder: ${err}`));
+            sendExerciseReminder(this.bot, this.chatbotService).catch((err) => this.logger.error(`Failed to re-send exercise reminder: ${err instanceof Error ? err.message : String(err)}`));
           }, EXERCISE_REMIND_DELAY_MS);
           await ctx.editMessageText('😴 Okay, I will remind you again in 1 hour.', { parse_mode: 'Markdown' }).catch(() => {});
           await ctx.answerCallbackQuery({ text: 'Reminding in 1 hour' }).catch(() => {});
           break;
       }
     } catch (err) {
-      this.logger.error(`Error handling exercise callback: ${err}`);
+      this.logger.error(`Error handling exercise callback: ${err instanceof Error ? err.message : String(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }
@@ -258,7 +258,7 @@ export class ChatbotController {
       const { message } = await this.chatbotService.processMessage(prompt, chatId);
       await sendRichMessage(this.bot, chatId, message);
     } catch (err) {
-      this.logger.error(`Error handling birthday callback: ${err}`);
+      this.logger.error(`Error handling birthday callback: ${err instanceof Error ? err.message : String(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true }).catch(() => {});
     }
   }

--- a/src/features/chatbot/chatbot.service.ts
+++ b/src/features/chatbot/chatbot.service.ts
@@ -75,7 +75,7 @@ export class ChatbotService {
       const structured = await structuredModel.invoke([new HumanMessage(agentResponse.message)]);
       return { response: agentResponse, structured: structured as z.infer<T> };
     } catch (err) {
-      this.logger.error(`Error processing message for user ${chatId}: ${err}`);
+      this.logger.error(`Error processing message for user ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
       if (responseSchema) {
         throw err;
       }

--- a/src/features/chatbot/chatbot.service.ts
+++ b/src/features/chatbot/chatbot.service.ts
@@ -7,7 +7,7 @@ import { summarizationMiddleware } from 'langchain';
 import { env } from 'node:process';
 import { z } from 'zod';
 import { DEFAULT_TIMEZONE, isProd } from '@core/config/main.config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import { recordModelUsage, ToolCallbackOptions, UsageCallbackHandler } from '@shared/ai';
 import { agent } from './agent';
@@ -75,7 +75,7 @@ export class ChatbotService {
       const structured = await structuredModel.invoke([new HumanMessage(agentResponse.message)]);
       return { response: agentResponse, structured: structured as z.infer<T> };
     } catch (err) {
-      this.logger.error(`Error processing message for user ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error processing message for user ${chatId}: ${getErrorMessage(err)}`);
       if (responseSchema) {
         throw err;
       }

--- a/src/features/chatbot/schedulers/birthday-reminder.ts
+++ b/src/features/chatbot/schedulers/birthday-reminder.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import { getTodayEvents } from '@shared/calendar-events';
 import { buildBirthdayKeyboard } from './birthday-actions';
@@ -22,6 +22,6 @@ export async function birthdayReminder(bot: Bot): Promise<void> {
       reply_markup: buildBirthdayKeyboard(),
     });
   } catch (err) {
-    logger.error(`Failed to send birthday reminder: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send birthday reminder: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/birthday-reminder.ts
+++ b/src/features/chatbot/schedulers/birthday-reminder.ts
@@ -22,6 +22,6 @@ export async function birthdayReminder(bot: Bot): Promise<void> {
       reply_markup: buildBirthdayKeyboard(),
     });
   } catch (err) {
-    logger.error(`Failed to send birthday reminder: ${err}`);
+    logger.error(`Failed to send birthday reminder: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/daily-summary.ts
+++ b/src/features/chatbot/schedulers/daily-summary.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import { getTomorrowEvents } from '@shared/calendar-events';
 import type { ChatbotService } from '../chatbot.service';
@@ -36,6 +36,6 @@ Please format the response nicely with emojis and make it feel like a friendly g
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your nightly summary.').catch(() => {});
-    logger.error(`Failed to generate/send daily summary: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to generate/send daily summary: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/daily-summary.ts
+++ b/src/features/chatbot/schedulers/daily-summary.ts
@@ -36,6 +36,6 @@ Please format the response nicely with emojis and make it feel like a friendly g
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your nightly summary.').catch(() => {});
-    logger.error(`Failed to generate/send daily summary: ${err}`);
+    logger.error(`Failed to generate/send daily summary: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/earthquake-monitor.ts
+++ b/src/features/chatbot/schedulers/earthquake-monitor.ts
@@ -63,7 +63,7 @@ export async function earthquakeMonitor(bot: Bot): Promise<void> {
 
         seenEarthquakeIds.add(quake.id);
       } catch (err) {
-        logger.error(`Failed to send alert for earthquake ${quake.id}: ${err.message}`);
+        logger.error(`Failed to send alert for earthquake ${quake.id}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 
@@ -77,7 +77,7 @@ export async function earthquakeMonitor(bot: Bot): Promise<void> {
 
     logger.log(`Successfully processed ${newEarthquakes.length} new earthquake(s)`);
   } catch (err) {
-    logger.error(`Failed to check earthquakes: ${err.message}`);
+    logger.error(`Failed to check earthquakes: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/features/chatbot/schedulers/earthquake-monitor.ts
+++ b/src/features/chatbot/schedulers/earthquake-monitor.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import { InputFile } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { type Earthquake, formatEarthquake, getRecentEarthquakes, shouldNotifyAboutEarthquake } from '@services/earthquake-api';
 import { generateEarthquakeMapImage } from '@services/earthquake-map';
 import { sendShortenedMessage } from '@services/telegram';
@@ -63,7 +63,7 @@ export async function earthquakeMonitor(bot: Bot): Promise<void> {
 
         seenEarthquakeIds.add(quake.id);
       } catch (err) {
-        logger.error(`Failed to send alert for earthquake ${quake.id}: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error(`Failed to send alert for earthquake ${quake.id}: ${getErrorMessage(err)}`);
       }
     }
 
@@ -77,7 +77,7 @@ export async function earthquakeMonitor(bot: Bot): Promise<void> {
 
     logger.log(`Successfully processed ${newEarthquakes.length} new earthquake(s)`);
   } catch (err) {
-    logger.error(`Failed to check earthquakes: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to check earthquakes: ${getErrorMessage(err)}`);
   }
 }
 

--- a/src/features/chatbot/schedulers/email-summary.ts
+++ b/src/features/chatbot/schedulers/email-summary.ts
@@ -41,6 +41,6 @@ Use the gmail tool with action "list" to fetch my 10 most recent unread emails (
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your email summary.').catch(() => {});
-    logger.error(`Failed to generate/send email summary: ${err}`);
+    logger.error(`Failed to generate/send email summary: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/email-summary.ts
+++ b/src/features/chatbot/schedulers/email-summary.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
 
@@ -41,6 +41,6 @@ Use the gmail tool with action "list" to fetch my 10 most recent unread emails (
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your email summary.').catch(() => {});
-    logger.error(`Failed to generate/send email summary: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to generate/send email summary: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/exercise-reminder.ts
+++ b/src/features/chatbot/schedulers/exercise-reminder.ts
@@ -30,6 +30,6 @@ export async function exerciseReminder(bot: Bot, chatbotService: ChatbotService)
   try {
     await sendExerciseReminder(bot, chatbotService);
   } catch (err) {
-    logger.error(`Failed to send exercise reminder: ${err}`);
+    logger.error(`Failed to send exercise reminder: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/exercise-reminder.ts
+++ b/src/features/chatbot/schedulers/exercise-reminder.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getTodayExercise } from '@shared/trainer';
 import type { ChatbotService } from '../chatbot.service';
 import { buildExerciseKeyboard } from './exercise-actions';
@@ -30,6 +30,6 @@ export async function exerciseReminder(bot: Bot, chatbotService: ChatbotService)
   try {
     await sendExerciseReminder(bot, chatbotService);
   } catch (err) {
-    logger.error(`Failed to send exercise reminder: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send exercise reminder: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-predictions-results.ts
+++ b/src/features/chatbot/schedulers/football-predictions-results.ts
@@ -57,6 +57,6 @@ Keep it engaging, honest about mistakes, and celebrate successes!`;
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send evening football update: ${err}`);
+    logger.error(`Failed to send evening football update: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-predictions-results.ts
+++ b/src/features/chatbot/schedulers/football-predictions-results.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateString } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
@@ -57,6 +57,6 @@ Keep it engaging, honest about mistakes, and celebrate successes!`;
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send evening football update: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send evening football update: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-predictions.ts
+++ b/src/features/chatbot/schedulers/football-predictions.ts
@@ -97,6 +97,6 @@ Important: Do NOT include any internal thoughts, reasoning about your process, o
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send football update: ${err}`);
+    logger.error(`Failed to send football update: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-predictions.ts
+++ b/src/features/chatbot/schedulers/football-predictions.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateString } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
@@ -97,6 +97,6 @@ Important: Do NOT include any internal thoughts, reasoning about your process, o
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send football update: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send football update: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-update.ts
+++ b/src/features/chatbot/schedulers/football-update.ts
@@ -31,6 +31,6 @@ export async function footballUpdate(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, `${response.message}${footer}`, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send football update: ${err}`);
+    logger.error(`Failed to send football update: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/football-update.ts
+++ b/src/features/chatbot/schedulers/football-update.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import { z } from 'zod';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateString } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
@@ -31,6 +31,6 @@ export async function footballUpdate(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, `${response.message}${footer}`, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send football update: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send football update: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/makavdia-update.ts
+++ b/src/features/chatbot/schedulers/makavdia-update.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import { z } from 'zod';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateString } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
@@ -32,6 +32,6 @@ export async function makavdiaUpdate(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send makavdia update: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send makavdia update: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/makavdia-update.ts
+++ b/src/features/chatbot/schedulers/makavdia-update.ts
@@ -32,6 +32,6 @@ export async function makavdiaUpdate(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send makavdia update: ${err}`);
+    logger.error(`Failed to send makavdia update: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/morning-brief.ts
+++ b/src/features/chatbot/schedulers/morning-brief.ts
@@ -2,7 +2,7 @@ import { endOfDay } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import type { Bot } from 'grammy';
 import { DEFAULT_TIMEZONE, MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import { getTodayEvents } from '@shared/calendar-events';
 import { getPendingRemindersDueOnOrBefore } from '@shared/reminders';
@@ -51,6 +51,6 @@ Please format the response nicely with emojis and make it feel like a friendly g
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your morning brief.').catch(() => {});
-    logger.error(`Failed to generate/send morning brief: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to generate/send morning brief: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/morning-brief.ts
+++ b/src/features/chatbot/schedulers/morning-brief.ts
@@ -51,6 +51,6 @@ Please format the response nicely with emojis and make it feel like a friendly g
     }
   } catch (err) {
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create your morning brief.').catch(() => {});
-    logger.error(`Failed to generate/send morning brief: ${err}`);
+    logger.error(`Failed to generate/send morning brief: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/polymarket-update.ts
+++ b/src/features/chatbot/schedulers/polymarket-update.ts
@@ -68,7 +68,7 @@ async function processBinarySubscription(chatId: number, subscription: Subscript
     updates.push({ subscription, market });
     await updateSubscription(subscription.marketId, chatId, { lastNotifiedPrice: market.yesPrice, marketQuestion: market.question });
   } catch (err) {
-    logger.error(`Failed to fetch market ${subscription.marketSlug}: ${err.message}`);
+    logger.error(`Failed to fetch market ${subscription.marketSlug}: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -87,6 +87,6 @@ async function processMultiOutcomeSubscription(chatId: number, subscription: Sub
     multiUpdates.push({ subscription, event });
     await updateSubscription(subscription.marketId, chatId, { lastNotifiedOutcomes: toOutcomeSnapshots(event), marketQuestion: event.title });
   } catch (err) {
-    logger.error(`Failed to fetch event ${subscription.marketSlug}: ${err.message}`);
+    logger.error(`Failed to fetch event ${subscription.marketSlug}: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/polymarket-update.ts
+++ b/src/features/chatbot/schedulers/polymarket-update.ts
@@ -1,5 +1,5 @@
 import type { Bot } from 'grammy';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getEventOutcomes, getMarketById } from '@services/polymarket';
 import { sendShortenedMessage } from '@services/telegram';
 import { getSubscriptionsGroupedByChatId, removeSubscription, updateSubscription } from '@shared/polymarket-follower';
@@ -68,7 +68,7 @@ async function processBinarySubscription(chatId: number, subscription: Subscript
     updates.push({ subscription, market });
     await updateSubscription(subscription.marketId, chatId, { lastNotifiedPrice: market.yesPrice, marketQuestion: market.question });
   } catch (err) {
-    logger.error(`Failed to fetch market ${subscription.marketSlug}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch market ${subscription.marketSlug}: ${getErrorMessage(err)}`);
   }
 }
 
@@ -87,6 +87,6 @@ async function processMultiOutcomeSubscription(chatId: number, subscription: Sub
     multiUpdates.push({ subscription, event });
     await updateSubscription(subscription.marketId, chatId, { lastNotifiedOutcomes: toOutcomeSnapshots(event), marketQuestion: event.title });
   } catch (err) {
-    logger.error(`Failed to fetch event ${subscription.marketSlug}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch event ${subscription.marketSlug}: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/rain-radar-alert.ts
+++ b/src/features/chatbot/schedulers/rain-radar-alert.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import { InputFile } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getCurrentWeather } from '@services/ims';
 import { generateRainRadarImage } from '@services/rain-radar';
 import { sendShortenedMessage } from '@services/telegram';
@@ -22,7 +22,7 @@ export async function rainRadarAlert(bot: Bot): Promise<void> {
     logger.log(`Rain chance in Kfar Saba: ${weather.chanceOfRain}% — generating radar image`);
 
     const radarResult = await generateRainRadarImage().catch((err) => {
-      logger.error(`Failed to generate radar image: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to generate radar image: ${getErrorMessage(err)}`);
       return undefined;
     });
 
@@ -38,6 +38,6 @@ export async function rainRadarAlert(bot: Bot): Promise<void> {
       logger.log('Sent rain radar alert (text only)');
     }
   } catch (err) {
-    logger.error(`Failed to check rain radar: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to check rain radar: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/rain-radar-alert.ts
+++ b/src/features/chatbot/schedulers/rain-radar-alert.ts
@@ -22,7 +22,7 @@ export async function rainRadarAlert(bot: Bot): Promise<void> {
     logger.log(`Rain chance in Kfar Saba: ${weather.chanceOfRain}% — generating radar image`);
 
     const radarResult = await generateRainRadarImage().catch((err) => {
-      logger.error(`Failed to generate radar image: ${err}`);
+      logger.error(`Failed to generate radar image: ${err instanceof Error ? err.message : String(err)}`);
       return undefined;
     });
 
@@ -38,6 +38,6 @@ export async function rainRadarAlert(bot: Bot): Promise<void> {
       logger.log('Sent rain radar alert (text only)');
     }
   } catch (err) {
-    logger.error(`Failed to check rain radar: ${err}`);
+    logger.error(`Failed to check rain radar: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/reminder-check.ts
+++ b/src/features/chatbot/schedulers/reminder-check.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDueReminders, markReminderNotified, reactivateSnoozedReminders } from '@shared/reminders';
 import { buildReminderKeyboard } from './reminder-actions';
 
@@ -32,12 +32,12 @@ export async function reminderCheck(bot: Bot): Promise<void> {
 
         logger.log(`Sent reminder ${reminder._id.toString()} to chat ${reminder.chatId}`);
       } catch (err) {
-        logger.error(`Failed to send reminder ${reminder._id.toString()} to chat ${reminder.chatId}: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error(`Failed to send reminder ${reminder._id.toString()} to chat ${reminder.chatId}: ${getErrorMessage(err)}`);
       }
     }
 
     logger.log(`Successfully processed ${dueReminders.length} reminder(s)`);
   } catch (err) {
-    logger.error(`Failed to check reminders: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to check reminders: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/reminder-check.ts
+++ b/src/features/chatbot/schedulers/reminder-check.ts
@@ -32,12 +32,12 @@ export async function reminderCheck(bot: Bot): Promise<void> {
 
         logger.log(`Sent reminder ${reminder._id.toString()} to chat ${reminder.chatId}`);
       } catch (err) {
-        logger.error(`Failed to send reminder ${reminder._id.toString()} to chat ${reminder.chatId}: ${err.message}`);
+        logger.error(`Failed to send reminder ${reminder._id.toString()} to chat ${reminder.chatId}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 
     logger.log(`Successfully processed ${dueReminders.length} reminder(s)`);
   } catch (err) {
-    logger.error(`Failed to check reminders: ${err.message}`);
+    logger.error(`Failed to check reminders: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/secretary-check-in.ts
+++ b/src/features/chatbot/schedulers/secretary-check-in.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID, WIFE_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { buildInlineKeyboard } from '@services/telegram';
 import { CHECK_IN_MESSAGE, CHECK_IN_SEND_CALLBACK, type SecretaryMessageService } from '../secretary';
 
@@ -15,6 +15,6 @@ export async function secretaryCheckIn(bot: Bot, messageService: SecretaryMessag
     const keyboard = buildInlineKeyboard([{ text: 'Send ✅', data: CHECK_IN_SEND_CALLBACK, style: 'success' }]);
     await bot.api.sendMessage(MY_USER_ID, `Send this to her?\n\n"${CHECK_IN_MESSAGE}"`, { reply_markup: keyboard });
   } catch (err) {
-    logger.error(`Failed to send check-in prompt: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send check-in prompt: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/secretary-check-in.ts
+++ b/src/features/chatbot/schedulers/secretary-check-in.ts
@@ -15,6 +15,6 @@ export async function secretaryCheckIn(bot: Bot, messageService: SecretaryMessag
     const keyboard = buildInlineKeyboard([{ text: 'Send ✅', data: CHECK_IN_SEND_CALLBACK, style: 'success' }]);
     await bot.api.sendMessage(MY_USER_ID, `Send this to her?\n\n"${CHECK_IN_MESSAGE}"`, { reply_markup: keyboard });
   } catch (err) {
-    logger.error(`Failed to send check-in prompt: ${err}`);
+    logger.error(`Failed to send check-in prompt: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/secretary-daily-digest.ts
+++ b/src/features/chatbot/schedulers/secretary-daily-digest.ts
@@ -35,6 +35,6 @@ export async function secretaryDailyDigest(bot: Bot, messageService: SecretaryMe
     const deleted = await messageService.clearMessagesBefore(cutoff);
     logger.log(`Sent ${summaries.length} daily summaries, cleared ${deleted} messages.`);
   } catch (err) {
-    logger.error(`Failed to send daily summaries: ${err}`);
+    logger.error(`Failed to send daily summaries: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/secretary-daily-digest.ts
+++ b/src/features/chatbot/schedulers/secretary-daily-digest.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import { randomUUID } from 'node:crypto';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import { buildActionsKeyboard, createActions, type CreateSecretaryActionData, type SecretaryMessageService, type SecretarySummaryAction, setActionsMessageId } from '../secretary';
 
@@ -35,6 +35,6 @@ export async function secretaryDailyDigest(bot: Bot, messageService: SecretaryMe
     const deleted = await messageService.clearMessagesBefore(cutoff);
     logger.log(`Sent ${summaries.length} daily summaries, cleared ${deleted} messages.`);
   } catch (err) {
-    logger.error(`Failed to send daily summaries: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send daily summaries: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/social-media-collect.ts
+++ b/src/features/chatbot/schedulers/social-media-collect.ts
@@ -1,4 +1,4 @@
-import { Logger, sleep } from '@core/utils';
+import { getErrorMessage, Logger, sleep } from '@core/utils';
 import { fetchChannelPosts as fetchTelegramChannelPosts } from '@services/telegram-scraper';
 import { getUserVideos } from '@services/tiktok';
 import { fetchLatestPosts as fetchTwitterLatestPosts } from '@services/twitter-scraper';
@@ -50,7 +50,7 @@ async function collectSubscription(subscription: SocialSubscription): Promise<vo
       logger.log(`Collected ${newPosts.length} new posts from ${platform}/@${username}`);
     }
   } catch (err) {
-    logger.error(`Failed to check ${platform}/@${username}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to check ${platform}/@${username}: ${getErrorMessage(err)}`);
   }
 }
 

--- a/src/features/chatbot/schedulers/social-media-collect.ts
+++ b/src/features/chatbot/schedulers/social-media-collect.ts
@@ -50,7 +50,7 @@ async function collectSubscription(subscription: SocialSubscription): Promise<vo
       logger.log(`Collected ${newPosts.length} new posts from ${platform}/@${username}`);
     }
   } catch (err) {
-    logger.error(`Failed to check ${platform}/@${username}: ${err.message}`);
+    logger.error(`Failed to check ${platform}/@${username}: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/features/chatbot/schedulers/social-media-digest.ts
+++ b/src/features/chatbot/schedulers/social-media-digest.ts
@@ -46,7 +46,7 @@ async function processDigestForChat(bot: Bot, chatId: number, posts: PendingPost
     try {
       sections.push(await buildUserSection(userPosts));
     } catch (err) {
-      logger.error(`Failed to build digest section for ${userPosts[0].platform}/@${userPosts[0].username}: ${err.message}`);
+      logger.error(`Failed to build digest section for ${userPosts[0].platform}/@${userPosts[0].username}: ${err instanceof Error ? err.message : String(err)}`);
       sections.push(buildListingSection(userPosts, MAX_FALLBACK_POSTS));
     }
   }
@@ -56,7 +56,7 @@ async function processDigestForChat(bot: Bot, chatId: number, posts: PendingPost
     await sendShortenedMessage(bot, chatId, message, { parse_mode: 'Markdown' }).catch(() => sendShortenedMessage(bot, chatId, message.replace(/[*_`[\]]/g, '')));
     await deletePendingPosts(posts.map((post) => post._id).filter(Boolean) as ObjectId[]);
   } catch (err) {
-    logger.error(`Failed to send digest to chat ${chatId}, keeping posts for next digest: ${err.message}`);
+    logger.error(`Failed to send digest to chat ${chatId}, keeping posts for next digest: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -129,7 +129,7 @@ async function shortenPosts(texts: (string | null)[]): Promise<string[]> {
     const shortenedByIndex = new Map(indexesToShorten.map((originalIndex, k) => [originalIndex, result.shortened[k]]));
     return texts.map((text, i) => shortenedByIndex.get(i) ?? text ?? '');
   } catch (err) {
-    logger.error(`Failed to shorten Telegram posts, falling back to truncation: ${err.message}`);
+    logger.error(`Failed to shorten Telegram posts, falling back to truncation: ${err instanceof Error ? err.message : String(err)}`);
     return texts.map((text) => (isLongPost(text) ? `${text.slice(0, LONG_POST_THRESHOLD)}…` : (text ?? '')));
   }
 }

--- a/src/features/chatbot/schedulers/social-media-digest.ts
+++ b/src/features/chatbot/schedulers/social-media-digest.ts
@@ -1,7 +1,7 @@
 import type { Bot } from 'grammy';
 import type { ObjectId } from 'mongodb';
 import { z } from 'zod';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getResponse } from '@services/openai';
 import { GPT_SMALL_MODEL } from '@services/openai/constants';
 import { sendShortenedMessage } from '@services/telegram';
@@ -46,7 +46,7 @@ async function processDigestForChat(bot: Bot, chatId: number, posts: PendingPost
     try {
       sections.push(await buildUserSection(userPosts));
     } catch (err) {
-      logger.error(`Failed to build digest section for ${userPosts[0].platform}/@${userPosts[0].username}: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to build digest section for ${userPosts[0].platform}/@${userPosts[0].username}: ${getErrorMessage(err)}`);
       sections.push(buildListingSection(userPosts, MAX_FALLBACK_POSTS));
     }
   }
@@ -56,7 +56,7 @@ async function processDigestForChat(bot: Bot, chatId: number, posts: PendingPost
     await sendShortenedMessage(bot, chatId, message, { parse_mode: 'Markdown' }).catch(() => sendShortenedMessage(bot, chatId, message.replace(/[*_`[\]]/g, '')));
     await deletePendingPosts(posts.map((post) => post._id).filter(Boolean) as ObjectId[]);
   } catch (err) {
-    logger.error(`Failed to send digest to chat ${chatId}, keeping posts for next digest: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send digest to chat ${chatId}, keeping posts for next digest: ${getErrorMessage(err)}`);
   }
 }
 
@@ -129,7 +129,7 @@ async function shortenPosts(texts: (string | null)[]): Promise<string[]> {
     const shortenedByIndex = new Map(indexesToShorten.map((originalIndex, k) => [originalIndex, result.shortened[k]]));
     return texts.map((text, i) => shortenedByIndex.get(i) ?? text ?? '');
   } catch (err) {
-    logger.error(`Failed to shorten Telegram posts, falling back to truncation: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to shorten Telegram posts, falling back to truncation: ${getErrorMessage(err)}`);
     return texts.map((text) => (isLongPost(text) ? `${text.slice(0, LONG_POST_THRESHOLD)}…` : (text ?? '')));
   }
 }

--- a/src/features/chatbot/schedulers/sports-calendar.ts
+++ b/src/features/chatbot/schedulers/sports-calendar.ts
@@ -89,6 +89,6 @@ export async function sportsCalendar(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to add important games to calendar: ${err}`);
+    logger.error(`Failed to add important games to calendar: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/sports-calendar.ts
+++ b/src/features/chatbot/schedulers/sports-calendar.ts
@@ -1,7 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
-import { getDateString } from '@core/utils';
+import { getDateString, getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import type { ChatbotService } from '../chatbot.service';
 
@@ -89,6 +88,6 @@ export async function sportsCalendar(bot: Bot, chatbotService: ChatbotService): 
       await sendShortenedMessage(bot, MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to add important games to calendar: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to add important games to calendar: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/spotify-podcast-update.ts
+++ b/src/features/chatbot/schedulers/spotify-podcast-update.ts
@@ -45,7 +45,7 @@ async function processSubscriptionsForChat(bot: Bot, chatId: number, subscriptio
         lastEpisodeReleaseDate: newEpisodes[0].release_date,
       });
     } catch (err) {
-      logger.error(`Failed to fetch episodes for show ${subscription.showName}: ${err.message}`);
+      logger.error(`Failed to fetch episodes for show ${subscription.showName}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/features/chatbot/schedulers/spotify-podcast-update.ts
+++ b/src/features/chatbot/schedulers/spotify-podcast-update.ts
@@ -1,5 +1,5 @@
 import type { Bot } from 'grammy';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getShowEpisodes, getSpotifyAccessToken } from '@services/spotify';
 import type { SpotifyEpisode } from '@services/spotify';
 import { sendShortenedMessage } from '@services/telegram';
@@ -45,7 +45,7 @@ async function processSubscriptionsForChat(bot: Bot, chatId: number, subscriptio
         lastEpisodeReleaseDate: newEpisodes[0].release_date,
       });
     } catch (err) {
-      logger.error(`Failed to fetch episodes for show ${subscription.showName}: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to fetch episodes for show ${subscription.showName}: ${getErrorMessage(err)}`);
     }
   }
 

--- a/src/features/chatbot/schedulers/upcoming-event-alert.ts
+++ b/src/features/chatbot/schedulers/upcoming-event-alert.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { DEFAULT_TIMEZONE, MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { CalendarEvent, listEvents } from '@services/google-calendar';
 
 const logger = new Logger('UpcomingEventAlertScheduler');
@@ -46,10 +46,10 @@ export async function upcomingEventAlert(bot: Bot): Promise<void> {
       try {
         await bot.api.sendMessage(MY_USER_ID, buildMessage(event), { parse_mode: 'Markdown' });
       } catch (err) {
-        logger.error(`Failed to send alert for event ${event.id}: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error(`Failed to send alert for event ${event.id}: ${getErrorMessage(err)}`);
       }
     }
   } catch (err) {
-    logger.error(`Failed to check upcoming events: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to check upcoming events: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/upcoming-event-alert.ts
+++ b/src/features/chatbot/schedulers/upcoming-event-alert.ts
@@ -46,10 +46,10 @@ export async function upcomingEventAlert(bot: Bot): Promise<void> {
       try {
         await bot.api.sendMessage(MY_USER_ID, buildMessage(event), { parse_mode: 'Markdown' });
       } catch (err) {
-        logger.error(`Failed to send alert for event ${event.id}: ${err.message}`);
+        logger.error(`Failed to send alert for event ${event.id}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   } catch (err) {
-    logger.error(`Failed to check upcoming events: ${err}`);
+    logger.error(`Failed to check upcoming events: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/usage-summary.ts
+++ b/src/features/chatbot/schedulers/usage-summary.ts
@@ -30,7 +30,7 @@ export async function usageSummary(bot: Bot): Promise<void> {
     const message = buildUsageSummaryMessage(rows, thisWeekRows, weekStartDay, from, to);
     await sendShortenedMessage(bot, MY_USER_ID, message, { parse_mode: 'Markdown' });
   } catch (err) {
-    logger.error(`Failed to send weekly usage summary: ${err}`);
+    logger.error(`Failed to send weekly usage summary: ${err instanceof Error ? err.message : String(err)}`);
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create the weekly usage summary.').catch(() => {});
   }
 }

--- a/src/features/chatbot/schedulers/usage-summary.ts
+++ b/src/features/chatbot/schedulers/usage-summary.ts
@@ -2,7 +2,7 @@ import { format, subDays } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import type { Bot } from 'grammy';
 import { DEFAULT_TIMEZONE, MY_USER_ID } from '@core/config';
-import { formatNumber, Logger } from '@core/utils';
+import { formatNumber, getErrorMessage, Logger } from '@core/utils';
 import { sendShortenedMessage } from '@services/telegram';
 import { aggregateUsage } from '@shared/ai';
 import type { UsageAggregateRow } from '@shared/ai';
@@ -30,7 +30,7 @@ export async function usageSummary(bot: Bot): Promise<void> {
     const message = buildUsageSummaryMessage(rows, thisWeekRows, weekStartDay, from, to);
     await sendShortenedMessage(bot, MY_USER_ID, message, { parse_mode: 'Markdown' });
   } catch (err) {
-    logger.error(`Failed to send weekly usage summary: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send weekly usage summary: ${getErrorMessage(err)}`);
     await bot.api.sendMessage(MY_USER_ID, '⚠️ Failed to create the weekly usage summary.').catch(() => {});
   }
 }

--- a/src/features/chatbot/schedulers/weekly-exercise-summary.ts
+++ b/src/features/chatbot/schedulers/weekly-exercise-summary.ts
@@ -22,6 +22,6 @@ export async function weeklyExerciseSummary(bot: Bot, chatbotService: ChatbotSer
       await bot.api.sendMessage(MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send weekly exercise summary: ${err}`);
+    logger.error(`Failed to send weekly exercise summary: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/features/chatbot/schedulers/weekly-exercise-summary.ts
+++ b/src/features/chatbot/schedulers/weekly-exercise-summary.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import type { ChatbotService } from '../chatbot.service';
 
 const logger = new Logger('WeeklyExerciseSummaryScheduler');
@@ -22,6 +22,6 @@ export async function weeklyExerciseSummary(bot: Bot, chatbotService: ChatbotSer
       await bot.api.sendMessage(MY_USER_ID, response.message, { parse_mode: 'Markdown' });
     }
   } catch (err) {
-    logger.error(`Failed to send weekly exercise summary: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send weekly exercise summary: ${getErrorMessage(err)}`);
   }
 }

--- a/src/features/chatbot/secretary/secretary-action.service.ts
+++ b/src/features/chatbot/secretary/secretary-action.service.ts
@@ -52,7 +52,7 @@ export class SecretaryActionService {
       const ok = toolMessages.length > 0 && !anyFailure;
       return { ok, text: ok ? text : text || 'The action could not be completed.' };
     } catch (err) {
-      this.logger.error(`Action execution failed: ${err}`);
+      this.logger.error(`Action execution failed: ${err instanceof Error ? err.message : String(err)}`);
       return { ok: false, text: `Failed to perform the action: ${err}` };
     }
   }

--- a/src/features/chatbot/secretary/secretary-action.service.ts
+++ b/src/features/chatbot/secretary/secretary-action.service.ts
@@ -3,7 +3,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import type { InlineKeyboard } from 'grammy';
 import { createAgent } from 'langchain';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import { buildInlineKeyboard } from '@services/telegram';
 import { calendarTool, recordModelUsage, reminderTool, UsageCallbackHandler } from '@shared/ai';
@@ -52,7 +52,7 @@ export class SecretaryActionService {
       const ok = toolMessages.length > 0 && !anyFailure;
       return { ok, text: ok ? text : text || 'The action could not be completed.' };
     } catch (err) {
-      this.logger.error(`Action execution failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Action execution failed: ${getErrorMessage(err)}`);
       return { ok: false, text: `Failed to perform the action: ${err}` };
     }
   }

--- a/src/features/chatbot/secretary/secretary-message.service.ts
+++ b/src/features/chatbot/secretary/secretary-message.service.ts
@@ -5,7 +5,7 @@ import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { env } from 'node:process';
 import { z } from 'zod';
 import { DEFAULT_TIMEZONE, WIFE_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
 import { deleteMessagesBefore, getMessagesForChatBetween, saveMessage, type SecretaryMessage, type SecretarySummaryAction } from './mongo';
@@ -96,7 +96,7 @@ export class SecretaryMessageService {
       const summary = `🗒️ Daily summary — ${otherName} (${dateStr})\n\n${body}`;
       return { summary, actions: (result.actions ?? []) as SecretarySummaryAction[] };
     } catch (err) {
-      this.logger.error(`Failed to summarize chat ${messages[0]?.chatId}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to summarize chat ${messages[0]?.chatId}: ${getErrorMessage(err)}`);
       return null;
     }
   }

--- a/src/features/chatbot/secretary/secretary-message.service.ts
+++ b/src/features/chatbot/secretary/secretary-message.service.ts
@@ -96,7 +96,7 @@ export class SecretaryMessageService {
       const summary = `🗒️ Daily summary — ${otherName} (${dateStr})\n\n${body}`;
       return { summary, actions: (result.actions ?? []) as SecretarySummaryAction[] };
     } catch (err) {
-      this.logger.error(`Failed to summarize chat ${messages[0]?.chatId}: ${err}`);
+      this.logger.error(`Failed to summarize chat ${messages[0]?.chatId}: ${err instanceof Error ? err.message : String(err)}`);
       return null;
     }
   }

--- a/src/features/chilli/chilli.service.ts
+++ b/src/features/chilli/chilli.service.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { env } from 'node:process';
 import { DEFAULT_TIMEZONE, isProd, MY_USER_ID } from '@core/config/main.config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { AiService, createAgentService } from '@features/chatbot/agent';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
@@ -44,7 +44,7 @@ export class ChilliService {
       const lastMessage = messages[messages.length - 1];
       return lastMessage.content as string;
     } catch (err) {
-      this.logger.error(`Error processing message for user ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error processing message for user ${chatId}: ${getErrorMessage(err)}`);
       return 'מיאו... משהו השתבש. נסו שוב.';
     }
   }

--- a/src/features/chilli/chilli.service.ts
+++ b/src/features/chilli/chilli.service.ts
@@ -44,7 +44,7 @@ export class ChilliService {
       const lastMessage = messages[messages.length - 1];
       return lastMessage.content as string;
     } catch (err) {
-      this.logger.error(`Error processing message for user ${chatId}: ${err}`);
+      this.logger.error(`Error processing message for user ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
       return 'מיאו... משהו השתבש. נסו שוב.';
     }
   }

--- a/src/features/coach/api/athlete-fetcher.ts
+++ b/src/features/coach/api/athlete-fetcher.ts
@@ -53,7 +53,7 @@ export async function fetchAthleteDetail(athleteId: number): Promise<AthleteDeta
       imageVersion: athlete.imageVersion,
     };
   } catch (err) {
-    logger.error(`fetchAthleteDetail failed for ${athleteId}: ${err}`);
+    logger.error(`fetchAthleteDetail failed for ${athleteId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/features/coach/api/athlete-fetcher.ts
+++ b/src/features/coach/api/athlete-fetcher.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { APP_TYPE_ID, COUNTRY_ID, LANGUAGE_ID, SCORES_365_API_URL } from '@services/scores-365';
 import type { AthleteDetailResponse } from './dto';
 
@@ -53,7 +53,7 @@ export async function fetchAthleteDetail(athleteId: number): Promise<AthleteDeta
       imageVersion: athlete.imageVersion,
     };
   } catch (err) {
-    logger.error(`fetchAthleteDetail failed for ${athleteId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`fetchAthleteDetail failed for ${athleteId}: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/features/coach/api/coach.api.controller.ts
+++ b/src/features/coach/api/coach.api.controller.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from 'express';
-import { getDateString, Logger } from '@core/utils';
+import { getDateString, getErrorMessage, Logger } from '@core/utils';
 import { notify } from '@services/notifier';
 import { COMPETITION_IDS_MAP } from '@services/scores-365';
 import type { TelegramBotConfig } from '@services/telegram';
@@ -122,7 +122,7 @@ export function registerCoachApiRoutes(app: Express, deps: CoachApiDeps): void {
       notify(botConfig, { action: 'FOLLOW_LEAGUE', competitionId: id, follow: body.follow, source: 'mini_app' }, userDetails);
       res.json({ following: isFollowing(id, next) });
     } catch (err) {
-      logger.error(`follow toggle failed for chatId=${chatId} id=${id}: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`follow toggle failed for chatId=${chatId} id=${id}: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });

--- a/src/features/coach/api/coach.api.controller.ts
+++ b/src/features/coach/api/coach.api.controller.ts
@@ -122,7 +122,7 @@ export function registerCoachApiRoutes(app: Express, deps: CoachApiDeps): void {
       notify(botConfig, { action: 'FOLLOW_LEAGUE', competitionId: id, follow: body.follow, source: 'mini_app' }, userDetails);
       res.json({ following: isFollowing(id, next) });
     } catch (err) {
-      logger.error(`follow toggle failed for chatId=${chatId} id=${id}: ${err}`);
+      logger.error(`follow toggle failed for chatId=${chatId} id=${id}: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });

--- a/src/features/coach/api/match-fetcher.ts
+++ b/src/features/coach/api/match-fetcher.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { APP_TYPE_ID, COUNTRY_ID, LANGUAGE_ID, SCORES_365_API_URL } from '@services/scores-365';
 import type { MatchDetails, Team } from '@services/scores-365';
 import type { LineupPlayer, LineupSide, MatchEvent, MatchSide, MatchSummary, RoundInfo } from './dto';
@@ -111,7 +111,7 @@ export async function fetchRichMatch(matchId: number): Promise<RichMatchData | n
       awayLineup: buildLineup(game.awayCompetitor, memberIndex),
     };
   } catch (err) {
-    logger.error(`fetchRichMatch failed: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`fetchRichMatch failed: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/features/coach/api/match-fetcher.ts
+++ b/src/features/coach/api/match-fetcher.ts
@@ -111,7 +111,7 @@ export async function fetchRichMatch(matchId: number): Promise<RichMatchData | n
       awayLineup: buildLineup(game.awayCompetitor, memberIndex),
     };
   } catch (err) {
-    logger.error(`fetchRichMatch failed: ${err}`);
+    logger.error(`fetchRichMatch failed: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/features/coach/api/team-fetcher.ts
+++ b/src/features/coach/api/team-fetcher.ts
@@ -115,7 +115,7 @@ export async function fetchTeamRecentMatches(teamId: number): Promise<TeamRecent
       .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
       .slice(0, RECENT_MATCH_LIMIT);
   } catch (err) {
-    logger.error(`fetchTeamRecentMatches failed for ${teamId}: ${err}`);
+    logger.error(`fetchTeamRecentMatches failed for ${teamId}: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }
@@ -150,7 +150,7 @@ export async function fetchTeamDetail(teamId: number): Promise<TeamDetailRespons
       squad,
     };
   } catch (err) {
-    logger.error(`fetchTeamDetail failed for ${teamId}: ${err}`);
+    logger.error(`fetchTeamDetail failed for ${teamId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/features/coach/api/team-fetcher.ts
+++ b/src/features/coach/api/team-fetcher.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { APP_TYPE_ID, COUNTRY_ID, LANGUAGE_ID, SCORES_365_API_URL } from '@services/scores-365';
 import type { MatchStatus, SquadPlayer, TeamDetailResponse, TeamRecentMatch } from './dto';
 
@@ -115,7 +115,7 @@ export async function fetchTeamRecentMatches(teamId: number): Promise<TeamRecent
       .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
       .slice(0, RECENT_MATCH_LIMIT);
   } catch (err) {
-    logger.error(`fetchTeamRecentMatches failed for ${teamId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`fetchTeamRecentMatches failed for ${teamId}: ${getErrorMessage(err)}`);
     return [];
   }
 }
@@ -150,7 +150,7 @@ export async function fetchTeamDetail(teamId: number): Promise<TeamDetailRespons
       squad,
     };
   } catch (err) {
-    logger.error(`fetchTeamDetail failed for ${teamId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`fetchTeamDetail failed for ${teamId}: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/features/coach/coach.controller.ts
+++ b/src/features/coach/coach.controller.ts
@@ -181,7 +181,7 @@ export class CoachController {
 
       await ctx.answerCallbackQuery().catch(() => {});
     } catch (err) {
-      this.logger.error(`Error handling callback query, ${err}`);
+      this.logger.error(`Error handling callback query, ${err instanceof Error ? err.message : String(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true });
     }
   }

--- a/src/features/coach/coach.controller.ts
+++ b/src/features/coach/coach.controller.ts
@@ -1,7 +1,7 @@
 import type { Bot, Context } from 'grammy';
 import { env } from 'node:process';
 import { MY_USER_NAME } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateDescription } from '@core/utils';
 import { notify } from '@services/notifier';
 import { COMPETITION_IDS_MAP } from '@services/scores-365';
@@ -181,7 +181,7 @@ export class CoachController {
 
       await ctx.answerCallbackQuery().catch(() => {});
     } catch (err) {
-      this.logger.error(`Error handling callback query, ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Error handling callback query, ${getErrorMessage(err)}`);
       await ctx.answerCallbackQuery({ text: 'Something went wrong. Please try again.', show_alert: true });
     }
   }

--- a/src/features/expenses/api/expenses.api.controller.ts
+++ b/src/features/expenses/api/expenses.api.controller.ts
@@ -409,7 +409,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const rows = await searchExpenses(q, 50);
       res.json({ expenses: rows.map(toExpenseDto) });
     } catch (err) {
-      logger.error(`search failed: ${err}`);
+      logger.error(`search failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'search_failed' });
     }
   });
@@ -435,7 +435,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       }));
       res.json({ subscriptions: dto });
     } catch (err) {
-      logger.error(`subscriptions failed: ${err}`);
+      logger.error(`subscriptions failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'subscriptions_failed' });
     }
   });
@@ -507,7 +507,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         anomalyExpenseIds,
       });
     } catch (err) {
-      logger.error(`expenses month failed: ${err}`);
+      logger.error(`expenses month failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'expenses_failed' });
     }
   });
@@ -531,7 +531,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       }
       res.json(buildCategoryDetail(category, scoped, scopeMonth, allCategoryExpenses));
     } catch (err) {
-      logger.error(`expenses category failed: ${err}`);
+      logger.error(`expenses category failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'category_failed' });
     }
   });
@@ -547,7 +547,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const expenses = await getAllExpensesByEffectiveVendor(name);
       res.json(buildVendorDetail(name, expenses));
     } catch (err) {
-      logger.error(`expenses vendor failed: ${err}`);
+      logger.error(`expenses vendor failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'vendor_failed' });
     }
   });
@@ -585,7 +585,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       res.json({ modifiedCount, vendor: buildVendorDetail(refreshedName, expenses) });
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.API_VENDOR_UPDATE, vendor: name, userVendor: body.userVendor, userCategory: body.userCategory, modifiedCount }, toUserDetails(req));
     } catch (err) {
-      logger.error(`expenses vendor bulk-update failed: ${err}`);
+      logger.error(`expenses vendor bulk-update failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'bulk_update_failed' });
     }
   });
@@ -637,7 +637,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         toUserDetails(req),
       );
     } catch (err) {
-      logger.error(`expense update failed: ${err}`);
+      logger.error(`expense update failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });
@@ -694,7 +694,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         toUserDetails(req),
       );
     } catch (err) {
-      logger.error(`manual expense create failed: ${err}`);
+      logger.error(`manual expense create failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -704,7 +704,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const cards = await getDistinctCards();
       res.json({ cards });
     } catch (err) {
-      logger.error(`list cards failed: ${err}`);
+      logger.error(`list cards failed: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'list_failed' });
     }
   });

--- a/src/features/expenses/api/expenses.api.controller.ts
+++ b/src/features/expenses/api/expenses.api.controller.ts
@@ -3,7 +3,7 @@ import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
 import type { Express, Request, Response } from 'express';
 import { ObjectId } from 'mongodb';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { notify } from '@services/notifier';
 import type { UserDetails } from '@services/telegram';
 import {
@@ -409,7 +409,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const rows = await searchExpenses(q, 50);
       res.json({ expenses: rows.map(toExpenseDto) });
     } catch (err) {
-      logger.error(`search failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`search failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'search_failed' });
     }
   });
@@ -435,7 +435,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       }));
       res.json({ subscriptions: dto });
     } catch (err) {
-      logger.error(`subscriptions failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`subscriptions failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'subscriptions_failed' });
     }
   });
@@ -507,7 +507,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         anomalyExpenseIds,
       });
     } catch (err) {
-      logger.error(`expenses month failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`expenses month failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'expenses_failed' });
     }
   });
@@ -531,7 +531,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       }
       res.json(buildCategoryDetail(category, scoped, scopeMonth, allCategoryExpenses));
     } catch (err) {
-      logger.error(`expenses category failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`expenses category failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'category_failed' });
     }
   });
@@ -547,7 +547,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const expenses = await getAllExpensesByEffectiveVendor(name);
       res.json(buildVendorDetail(name, expenses));
     } catch (err) {
-      logger.error(`expenses vendor failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`expenses vendor failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'vendor_failed' });
     }
   });
@@ -585,7 +585,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       res.json({ modifiedCount, vendor: buildVendorDetail(refreshedName, expenses) });
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.API_VENDOR_UPDATE, vendor: name, userVendor: body.userVendor, userCategory: body.userCategory, modifiedCount }, toUserDetails(req));
     } catch (err) {
-      logger.error(`expenses vendor bulk-update failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`expenses vendor bulk-update failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'bulk_update_failed' });
     }
   });
@@ -637,7 +637,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         toUserDetails(req),
       );
     } catch (err) {
-      logger.error(`expense update failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`expense update failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'update_failed' });
     }
   });
@@ -694,7 +694,7 @@ export function registerExpensesApiRoutes(app: Express): void {
         toUserDetails(req),
       );
     } catch (err) {
-      logger.error(`manual expense create failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`manual expense create failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'create_failed' });
     }
   });
@@ -704,7 +704,7 @@ export function registerExpensesApiRoutes(app: Express): void {
       const cards = await getDistinctCards();
       res.json({ cards });
     } catch (err) {
-      logger.error(`list cards failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`list cards failed: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'list_failed' });
     }
   });

--- a/src/features/expenses/expenses.controller.ts
+++ b/src/features/expenses/expenses.controller.ts
@@ -1,6 +1,6 @@
 import type { Bot, Context } from 'grammy';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { notify } from '@services/notifier';
 import { getMessageData, MessageLoader } from '@services/telegram';
 import { detectFormat, importParsedFiles, parseInput } from '@shared/expenses/importers';
@@ -96,8 +96,8 @@ export class ExpensesController {
         );
       } catch (err) {
         this.logger.error(`documentHandler ${fileName}: ${err instanceof Error ? (err.stack ?? err.message) : err}`);
-        await ctx.reply(`❌ \`${fileName}\` — failed to import: ${err instanceof Error ? err.message : String(err)}`, { parse_mode: 'Markdown' });
-        notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.IMPORT_FAILED, reason: 'error', fileName, error: err instanceof Error ? err.message : String(err) }, userDetails);
+        await ctx.reply(`❌ \`${fileName}\` — failed to import: ${getErrorMessage(err)}`, { parse_mode: 'Markdown' });
+        notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.IMPORT_FAILED, reason: 'error', fileName, error: getErrorMessage(err) }, userDetails);
       }
     });
   }

--- a/src/features/learner/api/learner.api.controller.ts
+++ b/src/features/learner/api/learner.api.controller.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from 'express';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { notify } from '@services/notifier';
 import type { TelegramBotConfig } from '@services/telegram';
 import { getProgress, type ReadMap, saveCourseProgress } from '../mongo';
@@ -57,7 +57,7 @@ export function registerLearnerApiRoutes(app: Express, deps: LearnerApiDeps): vo
       const courses = await getProgress(req.learnerUser!.chatId);
       res.json({ courses });
     } catch (err) {
-      logger.error(`Failed to load progress: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to load progress: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'load_failed' });
     }
   });
@@ -73,7 +73,7 @@ export function registerLearnerApiRoutes(app: Express, deps: LearnerApiDeps): vo
       await saveCourseProgress(req.learnerUser!.chatId, courseId, lessonIds as string[]);
       res.status(204).end();
     } catch (err) {
-      logger.error(`Failed to save progress: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to save progress: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'save_failed' });
     }
   });

--- a/src/features/learner/api/learner.api.controller.ts
+++ b/src/features/learner/api/learner.api.controller.ts
@@ -57,7 +57,7 @@ export function registerLearnerApiRoutes(app: Express, deps: LearnerApiDeps): vo
       const courses = await getProgress(req.learnerUser!.chatId);
       res.json({ courses });
     } catch (err) {
-      logger.error(`Failed to load progress: ${err}`);
+      logger.error(`Failed to load progress: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'load_failed' });
     }
   });
@@ -73,7 +73,7 @@ export function registerLearnerApiRoutes(app: Express, deps: LearnerApiDeps): vo
       await saveCourseProgress(req.learnerUser!.chatId, courseId, lessonIds as string[]);
       res.status(204).end();
     } catch (err) {
-      logger.error(`Failed to save progress: ${err}`);
+      logger.error(`Failed to save progress: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'save_failed' });
     }
   });

--- a/src/features/savings/api/savings.api.controller.ts
+++ b/src/features/savings/api/savings.api.controller.ts
@@ -56,7 +56,7 @@ export function registerSavingsApiRoutes(app: Express): void {
       const portfolio = (await getSavingsPortfolio()) ?? EMPTY_SAVINGS_PORTFOLIO;
       res.json({ portfolio: toSavingsPortfolioDto(portfolio) });
     } catch (err) {
-      logger.error(`Failed to load savings portfolio: ${err}`);
+      logger.error(`Failed to load savings portfolio: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'portfolio_load_failed' });
     }
   });
@@ -80,7 +80,7 @@ export function registerSavingsApiRoutes(app: Express): void {
 
       res.json({ portfolio: toSavingsPortfolioDto(result.portfolio) });
     } catch (err) {
-      logger.error(`Failed to save savings portfolio: ${err}`);
+      logger.error(`Failed to save savings portfolio: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ error: 'portfolio_save_failed' });
     }
   });

--- a/src/features/savings/api/savings.api.controller.ts
+++ b/src/features/savings/api/savings.api.controller.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, Response } from 'express';
 import { env } from 'node:process';
 import { isProd } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { SAVINGS_SESSION_COOKIE, SAVINGS_SESSION_TTL_SECONDS } from '../constants';
 import { getSavingsPortfolio, saveSavingsPortfolio } from '../mongo';
 import { createSavingsSessionToken, passwordsMatch } from './auth';
@@ -56,7 +56,7 @@ export function registerSavingsApiRoutes(app: Express): void {
       const portfolio = (await getSavingsPortfolio()) ?? EMPTY_SAVINGS_PORTFOLIO;
       res.json({ portfolio: toSavingsPortfolioDto(portfolio) });
     } catch (err) {
-      logger.error(`Failed to load savings portfolio: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to load savings portfolio: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'portfolio_load_failed' });
     }
   });
@@ -80,7 +80,7 @@ export function registerSavingsApiRoutes(app: Express): void {
 
       res.json({ portfolio: toSavingsPortfolioDto(result.portfolio) });
     } catch (err) {
-      logger.error(`Failed to save savings portfolio: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to save savings portfolio: ${getErrorMessage(err)}`);
       res.status(500).json({ error: 'portfolio_save_failed' });
     }
   });

--- a/src/features/wolt/restaurants.service.ts
+++ b/src/features/wolt/restaurants.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { RestaurantsList, WoltRestaurant } from '@shared/wolt';
 import { getRestaurantsList } from './utils';
 import { TOO_OLD_LIST_THRESHOLD_MS } from './wolt.config';
@@ -27,7 +27,7 @@ export class RestaurantsService {
         restaurantsList = { restaurants, lastUpdated: new Date().getTime() };
       }
     } catch (err) {
-      this.logger.error(`Failed to refresh restaurants list: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to refresh restaurants list: ${getErrorMessage(err)}`);
     }
   }
 }

--- a/src/features/wolt/restaurants.service.ts
+++ b/src/features/wolt/restaurants.service.ts
@@ -25,10 +25,9 @@ export class RestaurantsService {
       const restaurants = await getRestaurantsList();
       if (restaurants.length) {
         restaurantsList = { restaurants, lastUpdated: new Date().getTime() };
-        // this.logger.log(`${this.refreshRestaurants.name} - Restaurants list was refreshed successfully`);
       }
     } catch (err) {
-      this.logger.error(`${this.refreshRestaurants.name} - error - ${err}`);
+      this.logger.error(`Failed to refresh restaurants list: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 }

--- a/src/features/wolt/scripts/broadcast.ts
+++ b/src/features/wolt/scripts/broadcast.ts
@@ -42,12 +42,12 @@ async function sendToUser(bot: Bot, chatId: number): Promise<'sent' | 'blocked' 
           await bot.api.sendMessage(chatId, MESSAGE);
           return 'sent';
         } catch (retryErr) {
-          logger.error(`${sendToUser.name} - retry failed for ${chatId} - ${retryErr}`);
+          logger.error(`Retry failed for chatId ${chatId}: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`);
           return 'failed';
         }
       }
     }
-    logger.error(`${sendToUser.name} - failed for ${chatId} - ${err}`);
+    logger.error(`Failed to send broadcast to chatId ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
     return 'failed';
   }
 }
@@ -82,4 +82,4 @@ async function main(): Promise<void> {
   logger.log(`Done. sent=${tally.sent} blocked=${tally.blocked} failed=${tally.failed}`);
 }
 
-main().catch((err) => logger.error(`${err}`));
+main().catch((err) => logger.error(`${err instanceof Error ? err.message : String(err)}`));

--- a/src/features/wolt/scripts/broadcast.ts
+++ b/src/features/wolt/scripts/broadcast.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 import { Bot, GrammyError } from 'grammy';
 import { join } from 'node:path';
 import { argv, cwd, env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { BOT_CONFIG } from '../wolt.config';
 
 const logger = new Logger('wolt-broadcast');
@@ -42,12 +42,12 @@ async function sendToUser(bot: Bot, chatId: number): Promise<'sent' | 'blocked' 
           await bot.api.sendMessage(chatId, MESSAGE);
           return 'sent';
         } catch (retryErr) {
-          logger.error(`Retry failed for chatId ${chatId}: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`);
+          logger.error(`Retry failed for chatId ${chatId}: ${getErrorMessage(retryErr)}`);
           return 'failed';
         }
       }
     }
-    logger.error(`Failed to send broadcast to chatId ${chatId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send broadcast to chatId ${chatId}: ${getErrorMessage(err)}`);
     return 'failed';
   }
 }
@@ -82,4 +82,4 @@ async function main(): Promise<void> {
   logger.log(`Done. sent=${tally.sent} blocked=${tally.blocked} failed=${tally.failed}`);
 }
 
-main().catch((err) => logger.error(`${err instanceof Error ? err.message : String(err)}`));
+main().catch((err) => logger.error(`${getErrorMessage(err)}`));

--- a/src/features/wolt/scripts/check-subscriptions-areas.ts
+++ b/src/features/wolt/scripts/check-subscriptions-areas.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 import { MongoClient } from 'mongodb';
 import { join } from 'node:path';
 import { cwd, env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { DB_NAME, Subscription } from '@shared/wolt';
 import { getRestaurantsList } from '../utils';
 
@@ -48,7 +48,7 @@ async function main() {
     // logger.log('areasCount');
     // logger.log(areasCount);
   } catch (err) {
-    logger.error(`Error during insertion: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Error during insertion: ${getErrorMessage(err)}`);
   } finally {
     await client.close();
     logger.log('Disconnected from MongoDB.');

--- a/src/features/wolt/scripts/check-subscriptions-areas.ts
+++ b/src/features/wolt/scripts/check-subscriptions-areas.ts
@@ -48,7 +48,7 @@ async function main() {
     // logger.log('areasCount');
     // logger.log(areasCount);
   } catch (err) {
-    logger.error(`Error during insertion: ${err}`);
+    logger.error(`Error during insertion: ${err instanceof Error ? err.message : String(err)}`);
   } finally {
     await client.close();
     logger.log('Disconnected from MongoDB.');

--- a/src/features/wolt/scripts/get-available-areas.ts
+++ b/src/features/wolt/scripts/get-available-areas.ts
@@ -13,7 +13,7 @@ async function main() {
     logger.log('slugs');
     logger.log(slugs);
   } catch (err) {
-    logger.error(`Error during insertion: ${err}`);
+    logger.error(`Error during insertion: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/features/wolt/scripts/get-available-areas.ts
+++ b/src/features/wolt/scripts/get-available-areas.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getAllCities } from '../utils/get-restaurants-data';
 
 const logger = new Logger('get-available-areas');
@@ -13,7 +13,7 @@ async function main() {
     logger.log('slugs');
     logger.log(slugs);
   } catch (err) {
-    logger.error(`Error during insertion: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Error during insertion: ${getErrorMessage(err)}`);
   }
 }
 

--- a/src/features/wolt/utils/get-restaurants-data.ts
+++ b/src/features/wolt/utils/get-restaurants-data.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { env } from 'node:process';
-import { chunk, Logger, sleep } from '@core/utils';
+import { chunk, getErrorMessage, Logger, sleep } from '@core/utils';
 import type { WoltRestaurant } from '@shared/wolt';
 import {
   CITIES_BASE_URL,
@@ -89,7 +89,7 @@ export async function getRestaurantsList(): Promise<WoltRestaurant[]> {
 
     return restaurants;
   } catch (err) {
-    logger.error(`Failed to fetch restaurants list: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch restaurants list: ${getErrorMessage(err)}`);
     return [];
   }
 }
@@ -109,7 +109,7 @@ async function getCitiesList(): Promise<WoltCity[]> {
         return { areaSlug: slug, lon: location.coordinates[0], lat: location.coordinates[1] };
       });
   } catch (err) {
-    logger.error(`Failed to fetch cities list: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch cities list: ${getErrorMessage(err)}`);
     return [];
   }
 }

--- a/src/features/wolt/utils/get-restaurants-data.ts
+++ b/src/features/wolt/utils/get-restaurants-data.ts
@@ -84,12 +84,12 @@ export async function getRestaurantsList(): Promise<WoltRestaurant[]> {
     }
 
     if (failedAreas.length) {
-      logger.warn(`${getRestaurantsList.name} - could not fetch restaurants for areas: ${failedAreas.join(', ')}`);
+      logger.warn(`Could not fetch restaurants for areas: ${failedAreas.join(', ')}`);
     }
 
     return restaurants;
   } catch (err) {
-    logger.error(`${getRestaurantsList.name} - err - ${err}`);
+    logger.error(`Failed to fetch restaurants list: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }
@@ -109,7 +109,7 @@ async function getCitiesList(): Promise<WoltCity[]> {
         return { areaSlug: slug, lon: location.coordinates[0], lat: location.coordinates[1] };
       });
   } catch (err) {
-    logger.error(`${getCitiesList.name} - err - ${err}`);
+    logger.error(`Failed to fetch cities list: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }

--- a/src/features/wolt/utils/rank-restaurants-by-relevance.ts
+++ b/src/features/wolt/utils/rank-restaurants-by-relevance.ts
@@ -45,7 +45,7 @@ export async function rankRestaurantsByRelevance(restaurants: WoltRestaurant[], 
       return rankA - rankB;
     });
   } catch (err) {
-    logger.error(`Failed to rank restaurants: ${err}`);
+    logger.error(`Failed to rank restaurants: ${err instanceof Error ? err.message : String(err)}`);
     return restaurants;
   }
 }

--- a/src/features/wolt/utils/rank-restaurants-by-relevance.ts
+++ b/src/features/wolt/utils/rank-restaurants-by-relevance.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getResponse } from '@services/openai';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import type { WoltRestaurant } from '@shared/wolt';
@@ -45,7 +45,7 @@ export async function rankRestaurantsByRelevance(restaurants: WoltRestaurant[], 
       return rankA - rankB;
     });
   } catch (err) {
-    logger.error(`Failed to rank restaurants: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to rank restaurants: ${getErrorMessage(err)}`);
     return restaurants;
   }
 }

--- a/src/features/wolt/wolt-scheduler.service.ts
+++ b/src/features/wolt/wolt-scheduler.service.ts
@@ -1,7 +1,7 @@
 import { toZonedTime } from 'date-fns-tz';
 import { type Bot, InlineKeyboard } from 'grammy';
 import { DEFAULT_TIMEZONE } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { notify } from '@services/notifier';
 import { archiveSubscription, getActiveSubscriptions, getExpiredSubscriptions, getUserDetails, Subscription, WoltRestaurant } from '@shared/wolt';
 import { restaurantsService } from './restaurants.service';
@@ -29,7 +29,7 @@ export class WoltSchedulerService {
     await this.handleIntervalFlow();
 
     const timeout = setTimeout(() => {
-      this.scheduleInterval().catch((err) => this.logger.error(`Error in scheduled interval: ${err instanceof Error ? err.message : String(err)}`));
+      this.scheduleInterval().catch((err) => this.logger.error(`Error in scheduled interval: ${getErrorMessage(err)}`));
     }, secondsToNextRefresh * 1000);
 
     this.timeouts.set(JOB_NAME, timeout);
@@ -53,7 +53,7 @@ export class WoltSchedulerService {
       try {
         await this.bot.api.sendPhoto(chatId, restaurantPhoto, { reply_markup: keyboard, caption: replyText });
       } catch (err) {
-        this.logger.warn(`Failed to send alert photo for chatId ${chatId}, retrying without photo: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.warn(`Failed to send alert photo for chatId ${chatId}, retrying without photo: ${getErrorMessage(err)}`);
         notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ALERT_SUBSCRIPTION_FAILED, error: `${err}`, whatNow: 'retrying to alert the user without photo' });
         await this.bot.api.sendMessage(chatId, replyText, { reply_markup: keyboard });
       }
@@ -61,7 +61,7 @@ export class WoltSchedulerService {
       await archiveSubscription(chatId, restaurantName, true);
       await this.notifyWithUserDetails(chatId, restaurantName, ANALYTIC_EVENT_NAMES.SUBSCRIPTION_FULFILLED);
     } catch (err) {
-      this.logger.error(`Failed to alert subscription for chatId ${subscription.chatId}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to alert subscription for chatId ${subscription.chatId}: ${getErrorMessage(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ALERT_SUBSCRIPTION_FAILED, error: `${err}` });
     }
   }
@@ -91,7 +91,7 @@ export class WoltSchedulerService {
       }
       this.notifyWithUserDetails(chatId, restaurant, ANALYTIC_EVENT_NAMES.SUBSCRIPTION_FAILED);
     } catch (err) {
-      this.logger.error(`Failed to clean subscription for chatId ${subscription.chatId}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to clean subscription for chatId ${subscription.chatId}: ${getErrorMessage(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.CLEAN_EXPIRED_SUBSCRIPTION_FAILED, error: `${err}` });
     }
   }

--- a/src/features/wolt/wolt-scheduler.service.ts
+++ b/src/features/wolt/wolt-scheduler.service.ts
@@ -29,7 +29,7 @@ export class WoltSchedulerService {
     await this.handleIntervalFlow();
 
     const timeout = setTimeout(() => {
-      this.scheduleInterval().catch((err) => this.logger.error(`Error in scheduled interval: ${err}`));
+      this.scheduleInterval().catch((err) => this.logger.error(`Error in scheduled interval: ${err instanceof Error ? err.message : String(err)}`));
     }, secondsToNextRefresh * 1000);
 
     this.timeouts.set(JOB_NAME, timeout);
@@ -53,7 +53,7 @@ export class WoltSchedulerService {
       try {
         await this.bot.api.sendPhoto(chatId, restaurantPhoto, { reply_markup: keyboard, caption: replyText });
       } catch (err) {
-        this.logger.error(`${this.alertSubscription.name} - error - ${err}`);
+        this.logger.warn(`Failed to send alert photo for chatId ${chatId}, retrying without photo: ${err instanceof Error ? err.message : String(err)}`);
         notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ALERT_SUBSCRIPTION_FAILED, error: `${err}`, whatNow: 'retrying to alert the user without photo' });
         await this.bot.api.sendMessage(chatId, replyText, { reply_markup: keyboard });
       }
@@ -61,7 +61,7 @@ export class WoltSchedulerService {
       await archiveSubscription(chatId, restaurantName, true);
       await this.notifyWithUserDetails(chatId, restaurantName, ANALYTIC_EVENT_NAMES.SUBSCRIPTION_FULFILLED);
     } catch (err) {
-      this.logger.error(`${this.alertSubscription.name} - error - ${err}`);
+      this.logger.error(`Failed to alert subscription for chatId ${subscription.chatId}: ${err instanceof Error ? err.message : String(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ALERT_SUBSCRIPTION_FAILED, error: `${err}` });
     }
   }
@@ -91,7 +91,7 @@ export class WoltSchedulerService {
       }
       this.notifyWithUserDetails(chatId, restaurant, ANALYTIC_EVENT_NAMES.SUBSCRIPTION_FAILED);
     } catch (err) {
-      this.logger.error(`${this.cleanSubscription.name} - error - ${err}`);
+      this.logger.error(`Failed to clean subscription for chatId ${subscription.chatId}: ${err instanceof Error ? err.message : String(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.CLEAN_EXPIRED_SUBSCRIPTION_FAILED, error: `${err}` });
     }
   }

--- a/src/features/wolt/wolt.controller.ts
+++ b/src/features/wolt/wolt.controller.ts
@@ -1,7 +1,7 @@
 import type { Bot, Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 import { MY_USER_NAME } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getDateNumber, hasHebrew } from '@core/utils';
 import { notify } from '@services/notifier';
 import { buildInlineKeyboard, getCallbackQueryData, getMessageData, UserDetails } from '@services/telegram';
@@ -22,7 +22,7 @@ export class WoltController {
     this.bot.command(CONTACT.command.replace('/', ''), (ctx) => this.contactHandler(ctx));
     this.bot.on('message:text', (ctx) => this.textHandler(ctx));
     this.bot.on('callback_query:data', (ctx) => this.callbackQueryHandler(ctx));
-    this.bot.catch((err) => this.logger.error(`${err instanceof Error ? err.message : String(err)}`));
+    this.bot.catch((err) => this.logger.error(`${getErrorMessage(err)}`));
   }
 
   async startHandler(ctx: Context): Promise<void> {
@@ -159,7 +159,7 @@ export class WoltController {
         }
       }
     } catch (err) {
-      this.logger.error(`Failed to handle callback query: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to handle callback query: ${getErrorMessage(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ERROR, what: action, error: `${err}`, method: this.callbackQueryHandler.name }, userDetails);
       throw err;
     }

--- a/src/features/wolt/wolt.controller.ts
+++ b/src/features/wolt/wolt.controller.ts
@@ -22,7 +22,7 @@ export class WoltController {
     this.bot.command(CONTACT.command.replace('/', ''), (ctx) => this.contactHandler(ctx));
     this.bot.on('message:text', (ctx) => this.textHandler(ctx));
     this.bot.on('callback_query:data', (ctx) => this.callbackQueryHandler(ctx));
-    this.bot.catch((err) => this.logger.error(`${err}`));
+    this.bot.catch((err) => this.logger.error(`${err instanceof Error ? err.message : String(err)}`));
   }
 
   async startHandler(ctx: Context): Promise<void> {
@@ -159,7 +159,7 @@ export class WoltController {
         }
       }
     } catch (err) {
-      this.logger.error(`${this.callbackQueryHandler.name} - error - ${err}`);
+      this.logger.error(`Failed to handle callback query: ${err instanceof Error ? err.message : String(err)}`);
       notify(BOT_CONFIG, { action: ANALYTIC_EVENT_NAMES.ERROR, what: action, error: `${err}`, method: this.callbackQueryHandler.name }, userDetails);
       throw err;
     }

--- a/src/features/worldly/worldly.controller.ts
+++ b/src/features/worldly/worldly.controller.ts
@@ -30,7 +30,7 @@ export class WorldlyController {
     this.bot.command(CAPITAL.command.replace('/', ''), (ctx) => this.capitalHandler(ctx));
     this.bot.command(ACTIONS.command.replace('/', ''), (ctx) => this.actionsHandler(ctx));
     this.bot.on('callback_query:data', (ctx) => this.callbackQueryHandler(ctx));
-    this.bot.catch((err) => this.logger.error(`${err}`));
+    this.bot.catch((err) => this.logger.error(`${err instanceof Error ? err.message : String(err)}`));
   }
 
   async startHandler(ctx: Context): Promise<void> {

--- a/src/features/worldly/worldly.controller.ts
+++ b/src/features/worldly/worldly.controller.ts
@@ -1,6 +1,6 @@
 import type { Bot, Context } from 'grammy';
 import { MY_USER_NAME } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { sleep } from '@core/utils';
 import { notify } from '@services/notifier';
 import { buildInlineKeyboard, getCallbackQueryData, getMessageData, UserDetails } from '@services/telegram';
@@ -30,7 +30,7 @@ export class WorldlyController {
     this.bot.command(CAPITAL.command.replace('/', ''), (ctx) => this.capitalHandler(ctx));
     this.bot.command(ACTIONS.command.replace('/', ''), (ctx) => this.actionsHandler(ctx));
     this.bot.on('callback_query:data', (ctx) => this.callbackQueryHandler(ctx));
-    this.bot.catch((err) => this.logger.error(`${err instanceof Error ? err.message : String(err)}`));
+    this.bot.catch((err) => this.logger.error(`${getErrorMessage(err)}`));
   }
 
   async startHandler(ctx: Context): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { isProd } from '@core/config';
 import { closeMongoConnections } from '@core/mongo';
 import { registerSwaggerRoutes } from '@core/openapi';
 import { closeRedisConnection } from '@core/services';
-import { gracefulShutdown, Logger } from '@core/utils';
+import { getErrorMessage, gracefulShutdown, Logger } from '@core/utils';
 import { BOT_CONFIG as chatbotConfig, initChatbot } from '@features/chatbot';
 import { BOT_CONFIG as chilliConfig, initChilli } from '@features/chilli';
 import { BOT_CONFIG as coachConfig, initCoach } from '@features/coach';
@@ -36,7 +36,7 @@ async function main() {
   try {
     await initSavings(app);
   } catch (err) {
-    logger.error(`Failed to init savings app: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to init savings app: ${getErrorMessage(err)}`);
   }
 
   registerSwaggerRoutes(app);
@@ -47,7 +47,7 @@ async function main() {
     try {
       await init();
     } catch (err) {
-      logger.error(`Failed to init bot '${config.id}': ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to init bot '${config.id}': ${getErrorMessage(err)}`);
     }
   };
 
@@ -69,6 +69,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  new Logger('index').error(`Fatal error during startup: ${err instanceof Error ? err.message : String(err)}`);
+  new Logger('index').error(`Fatal error during startup: ${getErrorMessage(err)}`);
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ async function main() {
   // await initConsoleOverride();
   const app = express();
   const port = env.PORT || 3000;
-  const logger = new Logger('main.ts');
+  const logger = new Logger('index');
 
   app.use(express.json());
 
@@ -36,7 +36,7 @@ async function main() {
   try {
     await initSavings(app);
   } catch (err) {
-    logger.error(`Failed to init savings app: ${err}`);
+    logger.error(`Failed to init savings app: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   registerSwaggerRoutes(app);
@@ -47,7 +47,7 @@ async function main() {
     try {
       await init();
     } catch (err) {
-      logger.error(`Failed to init bot '${config.id}': ${err}`);
+      logger.error(`Failed to init bot '${config.id}': ${err instanceof Error ? err.message : String(err)}`);
     }
   };
 
@@ -69,6 +69,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  new Logger('main.ts').error(`Fatal error during startup: ${err}`);
+  new Logger('index').error(`Fatal error during startup: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 });

--- a/src/services/anthropic/utils/execute-tool.ts
+++ b/src/services/anthropic/utils/execute-tool.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { ANTHROPIC_DEFAULT_MAX_TOKENS, ANTHROPIC_OPUS_MODEL } from '../constants';
 import { provideAnthropicClient } from '../provide-anthropic-client';
 
@@ -26,7 +26,7 @@ export async function executeTool<T>(tool: Tool, content: string): Promise<T> {
 
     throw new Error('No tool output found in the response');
   } catch (err) {
-    logger.error(`Error executing tool ${tool.name}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Error executing tool ${tool.name}: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/services/anthropic/utils/execute-tool.ts
+++ b/src/services/anthropic/utils/execute-tool.ts
@@ -26,7 +26,7 @@ export async function executeTool<T>(tool: Tool, content: string): Promise<T> {
 
     throw new Error('No tool output found in the response');
   } catch (err) {
-    logger.error(`Error executing tool ${tool.name}: ${err}`);
+    logger.error(`Error executing tool ${tool.name}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/services/github/utils/add-labels.ts
+++ b/src/services/github/utils/add-labels.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse } from '../types';
 import { getOctokit } from './octokit';
@@ -20,7 +20,7 @@ export async function addLabels(issueNumber: number, labels: string[]): Promise<
       data: response.data.map((label) => (typeof label === 'string' ? label : label.name || '')),
     };
   } catch (err) {
-    const errorMsg = `Failed to add labels to #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to add labels to #${issueNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/create-issue-comment.ts
+++ b/src/services/github/utils/create-issue-comment.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, IssueComment } from '../types';
 import { mapComment } from './mappers';
@@ -21,7 +21,7 @@ export async function createIssueComment(issueNumber: number, body: string): Pro
       data: mapComment(response.data),
     };
   } catch (err) {
-    const errorMsg = `Failed to comment on issue #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to comment on issue #${issueNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/create-issue.ts
+++ b/src/services/github/utils/create-issue.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { CreateIssueInput, GitHubServiceResponse, Issue } from '../types';
 import { mapIssue } from './mappers';
@@ -23,7 +23,7 @@ export async function createIssue(input: CreateIssueInput): Promise<GitHubServic
       data: mapIssue(response.data),
     };
   } catch (err) {
-    const errorMsg = `Failed to create issue: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to create issue: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/create-pull-request-comment.ts
+++ b/src/services/github/utils/create-pull-request-comment.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, IssueComment } from '../types';
 import { mapComment } from './mappers';
@@ -21,7 +21,7 @@ export async function createPullRequestComment(prNumber: number, body: string): 
       data: mapComment(response.data),
     };
   } catch (err) {
-    const errorMsg = `Failed to comment on PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to comment on PR #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/get-issue.ts
+++ b/src/services/github/utils/get-issue.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, Issue } from '../types';
 import { mapIssue } from './mappers';
@@ -20,7 +20,7 @@ export async function getIssue(issueNumber: number): Promise<GitHubServiceRespon
       data: mapIssue(response.data),
     };
   } catch (err) {
-    const errorMsg = `Failed to get issue #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to get issue #${issueNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/get-pr-checks.ts
+++ b/src/services/github/utils/get-pr-checks.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, PullRequestCheck } from '../types';
 import { getOctokit } from './octokit';
@@ -32,7 +32,7 @@ export async function getPRChecks(prNumber: number): Promise<GitHubServiceRespon
 
     return { success: true, data: checks };
   } catch (err) {
-    const errorMsg = `Failed to get PR checks for #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to get PR checks for #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return { success: false, error: errorMsg };
   }

--- a/src/services/github/utils/get-pr-reviews.ts
+++ b/src/services/github/utils/get-pr-reviews.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, PullRequestReview } from '../types';
 import { getOctokit } from './octokit';
@@ -25,7 +25,7 @@ export async function getPRReviews(prNumber: number): Promise<GitHubServiceRespo
 
     return { success: true, data: reviews };
   } catch (err) {
-    const errorMsg = `Failed to get reviews for PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to get reviews for PR #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return { success: false, error: errorMsg };
   }

--- a/src/services/github/utils/get-pull-request.ts
+++ b/src/services/github/utils/get-pull-request.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, PullRequest } from '../types';
 import { mapPullRequest } from './mappers';
@@ -20,7 +20,7 @@ export async function getPullRequest(prNumber: number): Promise<GitHubServiceRes
       data: mapPullRequest(response.data as any),
     };
   } catch (err) {
-    const errorMsg = `Failed to get PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to get PR #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return { success: false, error: errorMsg };
   }

--- a/src/services/github/utils/list-issues.ts
+++ b/src/services/github/utils/list-issues.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, Issue } from '../types';
 import { mapIssue } from './mappers';
@@ -23,7 +23,7 @@ export async function listIssues(state?: string, labels?: string[]): Promise<Git
       data: response.data.map(mapIssue),
     };
   } catch (err) {
-    const errorMsg = `Failed to list issues: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to list issues: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/list-pr-files.ts
+++ b/src/services/github/utils/list-pr-files.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, PullRequestFile } from '../types';
 import { getOctokit } from './octokit';
@@ -24,7 +24,7 @@ export async function listPRFiles(prNumber: number): Promise<GitHubServiceRespon
 
     return { success: true, data: files };
   } catch (err) {
-    const errorMsg = `Failed to list files for PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to list files for PR #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return { success: false, error: errorMsg };
   }

--- a/src/services/github/utils/list-pull-requests.ts
+++ b/src/services/github/utils/list-pull-requests.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, PullRequest } from '../types';
 import { mapPullRequest } from './mappers';
@@ -22,7 +22,7 @@ export async function listPullRequests(state?: string): Promise<GitHubServiceRes
       data: response.data.map(mapPullRequest),
     };
   } catch (err) {
-    const errorMsg = `Failed to list pull requests: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to list pull requests: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/merge-pull-request.ts
+++ b/src/services/github/utils/merge-pull-request.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, MergePullRequestResult } from '../types';
 import { getOctokit } from './octokit';
@@ -26,7 +26,7 @@ export async function mergePullRequest(prNumber: number, mergeMethod: MergeMetho
       },
     };
   } catch (err) {
-    const errorMsg = `Failed to merge PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to merge PR #${prNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/trigger-workflow.ts
+++ b/src/services/github/utils/trigger-workflow.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER, HEROKU_DEPLOY_DEFAULT_REF } from '../constants';
 import type { GitHubServiceResponse, TriggerWorkflowResult } from '../types';
 import { getOctokit } from './octokit';
@@ -20,7 +20,7 @@ export async function triggerWorkflow(workflowFile: string, ref: string = HEROKU
       data: { workflow: workflowFile, ref },
     };
   } catch (err) {
-    const errorMsg = `Failed to trigger workflow '${workflowFile}' on ref '${ref}': ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to trigger workflow '${workflowFile}' on ref '${ref}': ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/github/utils/update-issue.ts
+++ b/src/services/github/utils/update-issue.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { GITHUB_REPO_NAME, GITHUB_REPO_OWNER } from '../constants';
 import type { GitHubServiceResponse, Issue, UpdateIssueInput } from '../types';
 import { mapIssue } from './mappers';
@@ -25,7 +25,7 @@ export async function updateIssue(issueNumber: number, input: UpdateIssueInput):
       data: mapIssue(response.data),
     };
   } catch (err) {
-    const errorMsg = `Failed to update issue #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Failed to update issue #${issueNumber}: ${getErrorMessage(err)}`;
     logger.error(errorMsg);
     return {
       success: false,

--- a/src/services/gmail/api.ts
+++ b/src/services/gmail/api.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { getGmailClient } from './auth';
 import { decodeBase64Url, extractBody, flattenParts, stripHtml } from './parts';
 
@@ -60,7 +60,7 @@ export async function fetchUserEmails(q: string, maxResults: number): Promise<Em
     }
     return cleanedEmails;
   } catch (err) {
-    logger.error(`Failed to fetch emails: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch emails: ${getErrorMessage(err)}`);
     return [];
   }
 }
@@ -70,7 +70,7 @@ export async function trashEmail(messageId: string) {
     const gmail = await getGmailClient();
     await gmail.users.messages.trash({ userId: 'me', id: messageId });
   } catch (err) {
-    logger.error(`Failed to trash email: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to trash email: ${getErrorMessage(err)}`);
     return null;
   }
 }
@@ -132,6 +132,6 @@ export async function sendEmail({ recipient, subject, body }: SendEmailOpts): Pr
     const res = await gmail.users.messages.send({ userId: 'me', requestBody: { raw: base64EncodedEmail } });
     return res.data.id;
   } catch (err) {
-    logger.error(`Failed to send email: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send email: ${getErrorMessage(err)}`);
   }
 }

--- a/src/services/gmail/api.ts
+++ b/src/services/gmail/api.ts
@@ -1,5 +1,8 @@
+import { Logger } from '@core/utils';
 import { getGmailClient } from './auth';
 import { decodeBase64Url, extractBody, flattenParts, stripHtml } from './parts';
+
+const logger = new Logger('gmail');
 
 type Email = {
   readonly id: string;
@@ -37,7 +40,7 @@ export async function fetchUserEmails(q: string, maxResults: number): Promise<Em
     const response = await gmail.users.messages.list({ userId: 'me', q, maxResults });
     const messages = response.data.messages || [];
     if (messages.length === 0) {
-      console.log('No new unread emails.');
+      logger.debug('No new unread emails');
       return;
     }
 
@@ -57,7 +60,7 @@ export async function fetchUserEmails(q: string, maxResults: number): Promise<Em
     }
     return cleanedEmails;
   } catch (err) {
-    console.error(`Error fetching emails: ${err}`);
+    logger.error(`Failed to fetch emails: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }
@@ -67,7 +70,7 @@ export async function trashEmail(messageId: string) {
     const gmail = await getGmailClient();
     await gmail.users.messages.trash({ userId: 'me', id: messageId });
   } catch (err) {
-    console.error(`Error trashing email: ${err}`);
+    logger.error(`Failed to trash email: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }
@@ -129,6 +132,6 @@ export async function sendEmail({ recipient, subject, body }: SendEmailOpts): Pr
     const res = await gmail.users.messages.send({ userId: 'me', requestBody: { raw: base64EncodedEmail } });
     return res.data.id;
   } catch (err) {
-    console.error(`Failed to send email: ${err}`);
+    logger.error(`Failed to send email: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/services/notifier/notify.ts
+++ b/src/services/notifier/notify.ts
@@ -1,5 +1,5 @@
 import { MY_USER_ID } from '@core/config';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { provideTelegramBot, TelegramBotConfig, UserDetails } from '@services/telegram';
 
 const logger = new Logger('notifier');
@@ -37,8 +37,8 @@ export function notify(bot: TelegramBotConfig, options: NotifyOptions, userDetai
   try {
     const notyMessageText = getNotyMessageText(bot.name, options, userDetails);
     const botInstance = provideTelegramBot(botConfig);
-    void botInstance.api.sendMessage(NOTIFIER_CHAT_ID, notyMessageText).catch((err) => logger.error(`Failed to send notification: ${err instanceof Error ? err.message : String(err)}`));
+    void botInstance.api.sendMessage(NOTIFIER_CHAT_ID, notyMessageText).catch((err) => logger.error(`Failed to send notification: ${getErrorMessage(err)}`));
   } catch (err) {
-    logger.error(`Failed to build notification: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to build notification: ${getErrorMessage(err)}`);
   }
 }

--- a/src/services/notifier/notify.ts
+++ b/src/services/notifier/notify.ts
@@ -37,8 +37,8 @@ export function notify(bot: TelegramBotConfig, options: NotifyOptions, userDetai
   try {
     const notyMessageText = getNotyMessageText(bot.name, options, userDetails);
     const botInstance = provideTelegramBot(botConfig);
-    void botInstance.api.sendMessage(NOTIFIER_CHAT_ID, notyMessageText).catch((err) => logger.error(`Failed to send notification: ${err}`));
+    void botInstance.api.sendMessage(NOTIFIER_CHAT_ID, notyMessageText).catch((err) => logger.error(`Failed to send notification: ${err instanceof Error ? err.message : String(err)}`));
   } catch (err) {
-    logger.error(`Failed to send notification: ${err}`);
+    logger.error(`Failed to build notification: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/services/rain-radar/api.ts
+++ b/src/services/rain-radar/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import fs from 'fs';
 import path from 'path';
 import sharp from 'sharp';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { DEFAULT_VIEW, IMS_RADAR_CONFIG } from './constants';
 import { createRadarOverlay, fetchMapTiles } from './map-utils';
 import type { GeneratedRadarImage, ImsRadarResponse, RainRadarOptions } from './types';
@@ -83,7 +83,7 @@ export async function generateRainRadarImage(options: RainRadarOptions = {}): Pr
       imageModified: latestImage.modified,
     };
   } catch (err) {
-    logger.error(`Failed to generate IMS radar image: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to generate IMS radar image: ${getErrorMessage(err)}`);
     throw new Error('IMS radar service is currently unavailable. Please try again later.');
   }
 }

--- a/src/services/rain-radar/api.ts
+++ b/src/services/rain-radar/api.ts
@@ -46,8 +46,8 @@ export async function generateRainRadarImage(options: RainRadarOptions = {}): Pr
         if (buf.length > 0) {
           radarBuffer = buf;
           latestImage = img;
-          logger.log(`Latest radar image: ${imageUrl}`);
-          logger.log(`Forecast time: ${latestImage.forecast_time}, Modified: ${latestImage.modified}`);
+          logger.debug(`Latest radar image: ${imageUrl}`);
+          logger.debug(`Forecast time: ${latestImage.forecast_time}, Modified: ${latestImage.modified}`);
           break;
         }
       } catch {
@@ -64,7 +64,7 @@ export async function generateRainRadarImage(options: RainRadarOptions = {}): Pr
     const overlay = await createRadarOverlay(radarBuffer, zoom, viewLeft, viewTop, width, height);
 
     // 4. Composite radar on map
-    logger.log('Compositing radar overlay on map...');
+    logger.debug('Compositing radar overlay on map...');
     const compositeImage = await sharp(mapBuffer).composite([overlay]).png().toBuffer();
 
     // 5. Save
@@ -83,7 +83,7 @@ export async function generateRainRadarImage(options: RainRadarOptions = {}): Pr
       imageModified: latestImage.modified,
     };
   } catch (err) {
-    logger.error(`Failed to generate IMS radar image: ${err}`);
+    logger.error(`Failed to generate IMS radar image: ${err instanceof Error ? err.message : String(err)}`);
     throw new Error('IMS radar service is currently unavailable. Please try again later.');
   }
 }

--- a/src/services/rain-radar/map-utils.ts
+++ b/src/services/rain-radar/map-utils.ts
@@ -101,7 +101,7 @@ export async function createRadarOverlay(radarBuffer: Buffer, zoom: number, view
   const radarX = Math.round(radarLeftPx - viewLeft);
   const radarY = Math.round(radarTopPx - viewTop);
 
-  logger.log(`Radar overlay: ${radarWidthPx}x${radarHeightPx}px, position: (${radarX}, ${radarY})`);
+  logger.debug(`Radar overlay: ${radarWidthPx}x${radarHeightPx}px, position: (${radarX}, ${radarY})`);
 
   const radarPng = await sharp(radarBuffer, { animated: false }).png().toBuffer();
   const resized = await sharp(radarPng).resize(radarWidthPx, radarHeightPx, { kernel: sharp.kernel.lanczos3 }).ensureAlpha().toBuffer();

--- a/src/services/telegram-client/provide-telegram-client.ts
+++ b/src/services/telegram-client/provide-telegram-client.ts
@@ -2,7 +2,7 @@ import { env } from 'node:process';
 import { TelegramClient } from 'telegram';
 import { LogLevel } from 'telegram/extensions/Logger.js';
 import { StringSession } from 'telegram/sessions/index.js';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 const logger = new Logger('TelegramClientProvider');
 const HEALTH_CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -27,11 +27,11 @@ export async function provideTelegramClient(): Promise<TelegramClient> {
         phoneNumber: null,
         password: null,
         phoneCode: null,
-        onError: (err) => logger.error(`${err instanceof Error ? err.message : String(err)}`),
+        onError: (err) => logger.error(`${getErrorMessage(err)}`),
       });
       await newClient.connect();
     } catch (err) {
-      logger.error(`Failed to connect telegram client: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to connect telegram client: ${getErrorMessage(err)}`);
       // Reset so a later call can retry with a fresh client instead of reusing a broken one.
       try {
         await newClient.disconnect();
@@ -63,7 +63,7 @@ function startHealthCheck(): void {
       await client.getMe();
       logger.log('Health check passed');
     } catch (err) {
-      logger.error(`Health check failed: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Health check failed: ${getErrorMessage(err)}`);
     }
   }, HEALTH_CHECK_INTERVAL_MS);
 }

--- a/src/services/telegram-client/provide-telegram-client.ts
+++ b/src/services/telegram-client/provide-telegram-client.ts
@@ -27,11 +27,11 @@ export async function provideTelegramClient(): Promise<TelegramClient> {
         phoneNumber: null,
         password: null,
         phoneCode: null,
-        onError: (err) => logger.error(`${err}`),
+        onError: (err) => logger.error(`${err instanceof Error ? err.message : String(err)}`),
       });
       await newClient.connect();
     } catch (err) {
-      logger.error(`Failed to connect telegram client: ${err}`);
+      logger.error(`Failed to connect telegram client: ${err instanceof Error ? err.message : String(err)}`);
       // Reset so a later call can retry with a fresh client instead of reusing a broken one.
       try {
         await newClient.disconnect();
@@ -63,7 +63,7 @@ function startHealthCheck(): void {
       await client.getMe();
       logger.log('Health check passed');
     } catch (err) {
-      logger.error(`Health check failed: ${err}`);
+      logger.error(`Health check failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }, HEALTH_CHECK_INTERVAL_MS);
 }

--- a/src/services/telegram-client/utils/fetch-new-messages.ts
+++ b/src/services/telegram-client/utils/fetch-new-messages.ts
@@ -1,7 +1,7 @@
 import bigInt from 'big-integer';
 import { Api, type TelegramClient } from 'telegram';
 import type { EntityLike } from 'telegram/define';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { provideTelegramClient } from '../provide-telegram-client';
 import { getConversationDetails } from './listen';
 import type { ConversationDetails, SenderDetails, TelegramMessage } from './listen';
@@ -36,7 +36,7 @@ export async function fetchLatestMessageId(channelId: string): Promise<number | 
     const messages = await client.getMessages(entity, { limit: 1 });
     return messages?.[0]?.id ?? null;
   } catch (err) {
-    logger.error(`Failed to fetch latest message id for ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch latest message id for ${channelId}: ${getErrorMessage(err)}`);
     return null;
   }
 }
@@ -73,7 +73,7 @@ export async function fetchNewChannelMessages(channelId: string, minId: number):
 
     return { conversation, latestId, items };
   } catch (err) {
-    logger.error(`Failed to fetch new messages for ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch new messages for ${channelId}: ${getErrorMessage(err)}`);
     return { conversation: null, latestId: minId, items: [] };
   }
 }

--- a/src/services/telegram-client/utils/fetch-new-messages.ts
+++ b/src/services/telegram-client/utils/fetch-new-messages.ts
@@ -36,7 +36,7 @@ export async function fetchLatestMessageId(channelId: string): Promise<number | 
     const messages = await client.getMessages(entity, { limit: 1 });
     return messages?.[0]?.id ?? null;
   } catch (err) {
-    logger.error(`Failed to fetch latest message id for ${channelId}: ${err}`);
+    logger.error(`Failed to fetch latest message id for ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }
@@ -73,7 +73,7 @@ export async function fetchNewChannelMessages(channelId: string, minId: number):
 
     return { conversation, latestId, items };
   } catch (err) {
-    logger.error(`Failed to fetch new messages for ${channelId}: ${err}`);
+    logger.error(`Failed to fetch new messages for ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
     return { conversation: null, latestId: minId, items: [] };
   }
 }

--- a/src/services/telegram-client/utils/listen.ts
+++ b/src/services/telegram-client/utils/listen.ts
@@ -1,7 +1,7 @@
 import { TelegramClient } from 'telegram';
 import type { EntityLike } from 'telegram/define';
 import { NewMessage, type NewMessageEvent } from 'telegram/events/index.js';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { EXCLUDED_CHANNELS } from '../constants';
 import { provideTelegramClient } from '../provide-telegram-client';
 
@@ -67,7 +67,7 @@ function extractMessageData(event: NewMessageEvent): TelegramMessage {
 
 export async function getConversationDetails(telegramClient: TelegramClient, entityId: EntityLike): Promise<ConversationDetails | null> {
   const entity = await telegramClient.getEntity(entityId).catch((err) => {
-    logger.error(`Failed to get conversation details for entity ${entityId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to get conversation details for entity ${entityId}: ${getErrorMessage(err)}`);
     return null;
   });
   return {
@@ -83,7 +83,7 @@ export async function getConversationDetails(telegramClient: TelegramClient, ent
 
 async function getSenderDetails(telegramClient: TelegramClient, userId: string): Promise<SenderDetails | null> {
   const user = await telegramClient.getEntity(userId).catch((err) => {
-    logger.error(`Failed to get sender details for user ${userId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to get sender details for user ${userId}: ${getErrorMessage(err)}`);
     return null;
   });
   if (!user) return null;
@@ -104,7 +104,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
     await telegramClient.getDialogs({});
     logger.log('Loaded dialogs into entity cache');
   } catch (err) {
-    logger.error(`Failed to start telegram client listener: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to start telegram client listener: ${getErrorMessage(err)}`);
     return;
   }
 
@@ -152,7 +152,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
         const senderDetails = userId ? await getSenderDetails(telegramClient, userId) : null;
         await callback(messageData, channelDetails, senderDetails);
       } catch (err) {
-        logger.error(`Error handling telegram event: ${err instanceof Error ? err.message : String(err)}`);
+        logger.error(`Error handling telegram event: ${getErrorMessage(err)}`);
       }
     },
     new NewMessage(includeOutgoing ? {} : { incoming: true }),

--- a/src/services/telegram-client/utils/listen.ts
+++ b/src/services/telegram-client/utils/listen.ts
@@ -67,7 +67,7 @@ function extractMessageData(event: NewMessageEvent): TelegramMessage {
 
 export async function getConversationDetails(telegramClient: TelegramClient, entityId: EntityLike): Promise<ConversationDetails | null> {
   const entity = await telegramClient.getEntity(entityId).catch((err) => {
-    logger.error(`Failed to get conversation details for entity ${entityId}: ${err}`);
+    logger.error(`Failed to get conversation details for entity ${entityId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   });
   return {
@@ -83,7 +83,7 @@ export async function getConversationDetails(telegramClient: TelegramClient, ent
 
 async function getSenderDetails(telegramClient: TelegramClient, userId: string): Promise<SenderDetails | null> {
   const user = await telegramClient.getEntity(userId).catch((err) => {
-    logger.error(`Failed to get sender details for user ${userId}: ${err}`);
+    logger.error(`Failed to get sender details for user ${userId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   });
   if (!user) return null;
@@ -104,7 +104,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
     await telegramClient.getDialogs({});
     logger.log('Loaded dialogs into entity cache');
   } catch (err) {
-    logger.error(`Failed to start telegram client listener: ${err}`);
+    logger.error(`Failed to start telegram client listener: ${err instanceof Error ? err.message : String(err)}`);
     return;
   }
 
@@ -112,7 +112,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
     async (event: NewMessageEvent) => {
       try {
         const messageData = extractMessageData(event);
-        logger.log(`[monitor] event received: channelId=${messageData?.channelId} userId=${messageData?.userId} isVoice=${messageData?.isVoice} hasText=${!!messageData?.text}`);
+        logger.debug(`Event received: channelId=${messageData?.channelId} userId=${messageData?.userId} isVoice=${messageData?.isVoice} hasText=${!!messageData?.text}`);
         if (!messageData?.text && !messageData?.isVoice) {
           return;
         }
@@ -120,7 +120,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
         const channelId = messageData.channelId;
         const userId = messageData.userId;
         if (conversationsIds.length && !conversationsIds.includes(channelId) && !conversationsIds.includes(userId)) {
-          logger.log(`[monitor] filtered out channelId=${channelId} userId=${userId} (not in conversationsIds)`);
+          logger.debug(`Filtered out message: channelId=${channelId} userId=${userId} (not in conversationsIds)`);
           return;
         }
 
@@ -152,7 +152,7 @@ export async function listen({ conversationsIds = [], includeOutgoing = false }:
         const senderDetails = userId ? await getSenderDetails(telegramClient, userId) : null;
         await callback(messageData, channelDetails, senderDetails);
       } catch (err) {
-        logger.error(`Error handling telegram event: ${err}`);
+        logger.error(`Error handling telegram event: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
     new NewMessage(includeOutgoing ? {} : { incoming: true }),

--- a/src/services/telegram-client/utils/send-message.ts
+++ b/src/services/telegram-client/utils/send-message.ts
@@ -1,5 +1,5 @@
 import { Api } from 'telegram';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { provideTelegramClient } from '../provide-telegram-client';
 import { Peer } from '../types';
 
@@ -30,7 +30,7 @@ export async function sendMessage({ name, number, message }: SendMessageOptions)
 
     return { peer: importedUser, id: sent.id };
   } catch (err) {
-    logger.error(`Failed to send telegram-client message: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to send telegram-client message: ${getErrorMessage(err)}`);
     return;
   }
 }

--- a/src/services/telegram-client/utils/send-message.ts
+++ b/src/services/telegram-client/utils/send-message.ts
@@ -30,7 +30,7 @@ export async function sendMessage({ name, number, message }: SendMessageOptions)
 
     return { peer: importedUser, id: sent.id };
   } catch (err) {
-    logger.error(`Failed to send telegram-client message: ${err}`);
+    logger.error(`Failed to send telegram-client message: ${err instanceof Error ? err.message : String(err)}`);
     return;
   }
 }

--- a/src/services/telegram/utils/message-streamer.ts
+++ b/src/services/telegram/utils/message-streamer.ts
@@ -1,6 +1,6 @@
 import type { Bot } from 'grammy';
 import { GrammyError } from 'grammy';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 const MIN_UPDATE_INTERVAL_MS = 500;
 const DEFAULT_UPDATE_INTERVAL_MS = 1500;
@@ -95,7 +95,7 @@ export class MessageStreamer {
         }
         return;
       }
-      this.logger.error(`Failed to send draft: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.error(`Failed to send draft: ${getErrorMessage(err)}`);
     }
   }
 }

--- a/src/services/telegram/utils/message-streamer.ts
+++ b/src/services/telegram/utils/message-streamer.ts
@@ -95,7 +95,7 @@ export class MessageStreamer {
         }
         return;
       }
-      this.logger.error(`Failed to send draft: ${err}`);
+      this.logger.error(`Failed to send draft: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 }

--- a/src/services/weather/weather.service.ts
+++ b/src/services/weather/weather.service.ts
@@ -10,14 +10,14 @@ export async function getCurrentWeather(location: string): Promise<CurrentWeathe
 
   if (imsLocationId) {
     try {
-      logger.log(`Using IMS for ${location} (ID: ${imsLocationId})`);
+      logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getCurrentWeather(imsLocationId);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
     }
   }
 
-  logger.log(`Using WeatherAPI for ${location}`);
+  logger.debug(`Using WeatherAPI for ${location}`);
   return weatherApi.getCurrentWeather(location);
 }
 
@@ -26,19 +26,19 @@ export async function getHourlyForecast(location: string, daysAhead: number = 0)
 
   if (imsLocationId) {
     if (daysAhead > 4) {
-      logger.log(`IMS only supports 5-day forecast, using WeatherAPI for ${location} (${daysAhead} days ahead)`);
+      logger.debug(`IMS only supports 5-day forecast, using WeatherAPI for ${location} (${daysAhead} days ahead)`);
       return await weatherApi.getHourlyForecast(location, daysAhead);
     }
 
     try {
-      logger.log(`Using IMS for ${location} (ID: ${imsLocationId})`);
+      logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getHourlyForecast(imsLocationId, daysAhead);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
     }
   }
 
-  logger.log(`Using WeatherAPI for ${location}`);
+  logger.debug(`Using WeatherAPI for ${location}`);
   return await weatherApi.getHourlyForecast(location, daysAhead);
 }
 
@@ -55,14 +55,14 @@ export async function getSpecificHourWeather(location: string, hour: number): Pr
 
   if (imsLocationId) {
     try {
-      logger.log(`Using IMS for ${location} (ID: ${imsLocationId})`);
+      logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getSpecificHourWeather(imsLocationId, hour);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
     }
   }
 
-  logger.log(`Using WeatherAPI for ${location}`);
+  logger.debug(`Using WeatherAPI for ${location}`);
   return await weatherApi.getSpecificHourWeather(location, hour);
 }
 
@@ -75,18 +75,18 @@ export async function getForecastWeather(location: string, date: string): Promis
     const diffDays = Math.ceil((targetDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 
     if (diffDays > 4) {
-      logger.log(`IMS only supports 5-day forecast, using WeatherAPI for ${location} (${date})`);
+      logger.debug(`IMS only supports 5-day forecast, using WeatherAPI for ${location} (${date})`);
       return await weatherApi.getForecastWeather(location, date);
     }
 
     try {
-      logger.log(`Using IMS for ${location} (ID: ${imsLocationId})`);
+      logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getForecastWeather(imsLocationId, date);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
     }
   }
 
-  logger.log(`Using WeatherAPI for ${location}`);
+  logger.debug(`Using WeatherAPI for ${location}`);
   return await weatherApi.getForecastWeather(location, date);
 }

--- a/src/services/weather/weather.service.ts
+++ b/src/services/weather/weather.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import * as imsApi from '@services/ims';
 import * as weatherApi from '@services/weather-api';
 import type { CurrentWeather, DayForecast, HourlyWeather, TomorrowForecast } from '@services/weather-api/types';
@@ -13,7 +13,7 @@ export async function getCurrentWeather(location: string): Promise<CurrentWeathe
       logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getCurrentWeather(imsLocationId);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${getErrorMessage(err)}, falling back to WeatherAPI`);
     }
   }
 
@@ -34,7 +34,7 @@ export async function getHourlyForecast(location: string, daysAhead: number = 0)
       logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getHourlyForecast(imsLocationId, daysAhead);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${getErrorMessage(err)}, falling back to WeatherAPI`);
     }
   }
 
@@ -58,7 +58,7 @@ export async function getSpecificHourWeather(location: string, hour: number): Pr
       logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getSpecificHourWeather(imsLocationId, hour);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${getErrorMessage(err)}, falling back to WeatherAPI`);
     }
   }
 
@@ -83,7 +83,7 @@ export async function getForecastWeather(location: string, date: string): Promis
       logger.debug(`Using IMS for ${location} (ID: ${imsLocationId})`);
       return await imsApi.getForecastWeather(imsLocationId, date);
     } catch (err) {
-      logger.warn(`IMS failed for ${location}: ${err instanceof Error ? err.message : String(err)}, falling back to WeatherAPI`);
+      logger.warn(`IMS failed for ${location}: ${getErrorMessage(err)}, falling back to WeatherAPI`);
     }
   }
 

--- a/src/services/youtube-v3/api.ts
+++ b/src/services/youtube-v3/api.ts
@@ -1,8 +1,11 @@
 import axios from 'axios';
 import { env } from 'node:process';
+import { Logger } from '@core/utils';
 import type { Video, YouTubeChannelResponse, YouTubeSearchResponse } from './types';
 
 const YOUTUBE_API_BASE_URL = 'https://www.googleapis.com/youtube/v3';
+
+const logger = new Logger('youtube-v3');
 
 export async function getChannelIdFromHandle(handle: string): Promise<string> {
   const apiKey = env.YOUTUBE_API_KEY;
@@ -56,7 +59,7 @@ export async function fetchTranscript(videoId: string): Promise<string> {
   }
 
   try {
-    console.log(`fetchTranscript: Fetching transcript for videoId: ${videoId} using RapidAPI`);
+    logger.debug(`Fetching transcript for videoId ${videoId} using RapidAPI`);
 
     const response = await axios.get('https://youtube-transcriptor.p.rapidapi.com/transcript', {
       params: {
@@ -70,20 +73,20 @@ export async function fetchTranscript(videoId: string): Promise<string> {
     });
 
     if (!response.data || response.data.error) {
-      console.log(`fetchTranscript: No transcript available for videoId: ${videoId}`);
+      logger.debug(`No transcript available for videoId ${videoId}`);
       return null;
     }
 
     if (Array.isArray(response.data)) {
       const fullText = response.data[0].transcriptionAsText;
-      console.log(`fetchTranscript: Successfully fetched transcript for videoId: ${videoId}, length: ${fullText.length} characters`);
+      logger.debug(`Successfully fetched transcript for videoId ${videoId}, length: ${fullText.length} characters`);
       return fullText;
     }
 
-    console.log(`fetchTranscript: Unexpected response format for videoId: ${videoId}`);
+    logger.warn(`Unexpected response format for videoId ${videoId}`);
     return null;
   } catch (err) {
-    console.error(`fetchTranscript: Failed to fetch transcript for videoId: ${videoId}: ${err.message}`);
+    logger.error(`Failed to fetch transcript for videoId ${videoId}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/services/youtube-v3/api.ts
+++ b/src/services/youtube-v3/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import type { Video, YouTubeChannelResponse, YouTubeSearchResponse } from './types';
 
 const YOUTUBE_API_BASE_URL = 'https://www.googleapis.com/youtube/v3';
@@ -86,7 +86,7 @@ export async function fetchTranscript(videoId: string): Promise<string> {
     logger.warn(`Unexpected response format for videoId ${videoId}`);
     return null;
   } catch (err) {
-    logger.error(`Failed to fetch transcript for videoId ${videoId}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Failed to fetch transcript for videoId ${videoId}: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/shared/ai/tools/earthquake/earthquake.tool.ts
+++ b/src/shared/ai/tools/earthquake/earthquake.tool.ts
@@ -1,7 +1,10 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
+import { Logger } from '@core/utils';
 import { formatEarthquake, getEarthquakesAboveMagnitude, getRecentEarthquakes, shouldNotifyAboutEarthquake } from '@services/earthquake-api';
 import { generateEarthquakeMapImage } from '@services/earthquake-map';
+
+const logger = new Logger('earthquake-tool');
 
 const schema = z.object({
   action: z.enum(['recent', 'magnitude']).describe('Action to perform: "recent" for recent earthquakes, "magnitude" for earthquakes above a threshold'),
@@ -52,7 +55,7 @@ async function runner({ action, limit, minMagnitude, hoursBack }: z.infer<typeof
         place: firstQuake.properties.place,
       });
     } catch (err) {
-      console.error(`Failed to generate earthquake map: ${err}`);
+      logger.error(`Failed to generate earthquake map: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     const formattedQuakes = relevantEarthquakes.map((quake, index) => {

--- a/src/shared/ai/tools/earthquake/earthquake.tool.ts
+++ b/src/shared/ai/tools/earthquake/earthquake.tool.ts
@@ -1,6 +1,6 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { formatEarthquake, getEarthquakesAboveMagnitude, getRecentEarthquakes, shouldNotifyAboutEarthquake } from '@services/earthquake-api';
 import { generateEarthquakeMapImage } from '@services/earthquake-map';
 
@@ -55,7 +55,7 @@ async function runner({ action, limit, minMagnitude, hoursBack }: z.infer<typeof
         place: firstQuake.properties.place,
       });
     } catch (err) {
-      logger.error(`Failed to generate earthquake map: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to generate earthquake map: ${getErrorMessage(err)}`);
     }
 
     const formattedQuakes = relevantEarthquakes.map((quake, index) => {

--- a/src/shared/ai/tools/maps/utils/get-map-images.ts
+++ b/src/shared/ai/tools/maps/utils/get-map-images.ts
@@ -1,7 +1,7 @@
 import { env } from 'node:process';
 import * as path from 'path';
 import { LOCAL_FILES_PATH } from '@core/config';
-import { deleteFile, Logger } from '@core/utils';
+import { deleteFile, getErrorMessage, Logger } from '@core/utils';
 import { imgurUploadImage } from '@services/imgur';
 import { downloadImage } from './download-image';
 import { findPlace, PlaceInfo } from './find-place';
@@ -41,7 +41,7 @@ export async function getMapImages(placeName: string): Promise<MapImagesResult> 
 
     return { success: true, placeName, placeInfo, mapImageUrl };
   } catch (err) {
-    logger.error(`Error getting map images: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Error getting map images: ${getErrorMessage(err)}`);
     return { success: false, placeName, error: err.message || 'Unknown error occurred' };
   }
 }

--- a/src/shared/ai/tools/maps/utils/get-map-images.ts
+++ b/src/shared/ai/tools/maps/utils/get-map-images.ts
@@ -41,7 +41,7 @@ export async function getMapImages(placeName: string): Promise<MapImagesResult> 
 
     return { success: true, placeName, placeInfo, mapImageUrl };
   } catch (err) {
-    logger.error(`Error getting map images: ${err}`);
+    logger.error(`Error getting map images: ${err instanceof Error ? err.message : String(err)}`);
     return { success: false, placeName, error: err.message || 'Unknown error occurred' };
   }
 }

--- a/src/shared/ai/tools/maps/utils/get-place-details.ts
+++ b/src/shared/ai/tools/maps/utils/get-place-details.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { env } from 'node:process';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { findPlace } from './find-place';
 
 const logger = new Logger('get-place-details');
@@ -72,7 +72,7 @@ export async function getPlaceDetails(placeName: string): Promise<PlaceDetailsRe
       };
     }
   } catch (err) {
-    logger.error(`Error getting place details: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`Error getting place details: ${getErrorMessage(err)}`);
     return {
       success: false,
       error: err.message || 'Unknown error occurred',

--- a/src/shared/ai/tools/maps/utils/get-place-details.ts
+++ b/src/shared/ai/tools/maps/utils/get-place-details.ts
@@ -72,7 +72,7 @@ export async function getPlaceDetails(placeName: string): Promise<PlaceDetailsRe
       };
     }
   } catch (err) {
-    logger.error(`Error getting place details: ${err}`);
+    logger.error(`Error getting place details: ${err instanceof Error ? err.message : String(err)}`);
     return {
       success: false,
       error: err.message || 'Unknown error occurred',

--- a/src/shared/ai/usage/record-usage.ts
+++ b/src/shared/ai/usage/record-usage.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import type { UsageCallbackHandler } from '../utils';
 import { saveUsageRecord } from './usage.repository';
 
@@ -34,5 +34,5 @@ export function recordModelUsage({ source, chatId, handler, durationMs }: Record
     durationMs,
     llmCalls: usage.llmCalls,
     toolCalls: usage.toolCalls,
-  }).catch((err) => logger.error(`Failed to persist usage record (source=${source}): ${err instanceof Error ? err.message : String(err)}`));
+  }).catch((err) => logger.error(`Failed to persist usage record (source=${source}): ${getErrorMessage(err)}`));
 }

--- a/src/shared/ai/usage/record-usage.ts
+++ b/src/shared/ai/usage/record-usage.ts
@@ -34,5 +34,5 @@ export function recordModelUsage({ source, chatId, handler, durationMs }: Record
     durationMs,
     llmCalls: usage.llmCalls,
     toolCalls: usage.toolCalls,
-  }).catch((err) => logger.error(`Failed to persist usage record (source=${source}): ${err}`));
+  }).catch((err) => logger.error(`Failed to persist usage record (source=${source}): ${err instanceof Error ? err.message : String(err)}`));
 }

--- a/src/shared/ai/utils/tool-callback-handler.ts
+++ b/src/shared/ai/utils/tool-callback-handler.ts
@@ -35,7 +35,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolStart(toolName, input, metadata);
       } catch (err) {
-        this.logger.error(`Error in onToolStart callback for ${toolName}: ${err}`);
+        this.logger.error(`Error in onToolStart callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }
@@ -55,7 +55,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolEnd(toolName || 'unknown', output, { duration });
       } catch (err) {
-        this.logger.error(`Error in onToolEnd callback for ${toolName}: ${err}`);
+        this.logger.error(`Error in onToolEnd callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }
@@ -75,7 +75,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolError(toolName || 'unknown', error, { duration });
       } catch (err) {
-        this.logger.error(`Error in onToolError callback for ${toolName}: ${err}`);
+        this.logger.error(`Error in onToolError callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   }

--- a/src/shared/ai/utils/tool-callback-handler.ts
+++ b/src/shared/ai/utils/tool-callback-handler.ts
@@ -1,6 +1,6 @@
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { Serialized } from '@langchain/core/load/serializable';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 export type ToolCallbackOptions = {
   onToolStart?: (toolName: string, input: any, metadata?: Record<string, unknown>) => void | Promise<void>;
@@ -35,7 +35,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolStart(toolName, input, metadata);
       } catch (err) {
-        this.logger.error(`Error in onToolStart callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.error(`Error in onToolStart callback for ${toolName}: ${getErrorMessage(err)}`);
       }
     }
   }
@@ -55,7 +55,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolEnd(toolName || 'unknown', output, { duration });
       } catch (err) {
-        this.logger.error(`Error in onToolEnd callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.error(`Error in onToolEnd callback for ${toolName}: ${getErrorMessage(err)}`);
       }
     }
   }
@@ -75,7 +75,7 @@ export class ToolCallbackHandler extends BaseCallbackHandler {
       try {
         await this.options.onToolError(toolName || 'unknown', error, { duration });
       } catch (err) {
-        this.logger.error(`Error in onToolError callback for ${toolName}: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.error(`Error in onToolError callback for ${toolName}: ${getErrorMessage(err)}`);
       }
     }
   }

--- a/src/shared/calendar-events/calendar-events.api.controller.ts
+++ b/src/shared/calendar-events/calendar-events.api.controller.ts
@@ -105,7 +105,7 @@ export function registerCalendarEventsRoutes(app: Express): void {
 
       res.json({ success: true, data: result });
     } catch (err) {
-      logger.error(`Failed to sync calendar events: ${err}`);
+      logger.error(`Failed to sync calendar events: ${err instanceof Error ? err.message : String(err)}`);
       res.status(500).json({ success: false, error: 'Internal server error' });
     }
   });

--- a/src/shared/calendar-events/calendar-events.api.controller.ts
+++ b/src/shared/calendar-events/calendar-events.api.controller.ts
@@ -2,7 +2,7 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import type { Express, Request, Response } from 'express';
 import { z } from 'zod';
 import { registry } from '@core/openapi';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { upsertCalendarEvents } from './mongo';
 import type { CreateCalendarEventData } from './types';
 
@@ -105,7 +105,7 @@ export function registerCalendarEventsRoutes(app: Express): void {
 
       res.json({ success: true, data: result });
     } catch (err) {
-      logger.error(`Failed to sync calendar events: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error(`Failed to sync calendar events: ${getErrorMessage(err)}`);
       res.status(500).json({ success: false, error: 'Internal server error' });
     }
   });

--- a/src/shared/expenses/importers/import-rows.ts
+++ b/src/shared/expenses/importers/import-rows.ts
@@ -1,6 +1,7 @@
 // Reusable importer pipeline — used by both the standalone script and the expenses bot's
 // document-upload handler. Caller supplies parsed rows; we handle dedup + override-inheritance
 // + insertion. Pure of any file-system / Telegram concerns.
+import { getErrorMessage } from '@core/utils';
 import { createExpense, type CreateExpenseData, effectiveVendor, type Expense, getAllOverriddenExpenses, getExpensesBetween } from '@shared/expenses';
 import { findDuplicate, normalizeName } from './dedup';
 import { parseDiscountFile } from './discount-parser';
@@ -147,7 +148,7 @@ export async function importParsedFiles(parsedFiles: ReadonlyArray<{ readonly me
           liveExisting.push(newExpense);
           registerOverride(overrideMap, newExpense);
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = getErrorMessage(err);
           if (message.includes('E11000') || message.toLowerCase().includes('duplicate key')) {
             skipped++;
             continue;

--- a/src/shared/expenses/utils/manual-entry.ts
+++ b/src/shared/expenses/utils/manual-entry.ts
@@ -2,7 +2,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import { ObjectId } from 'mongodb';
 import { env } from 'node:process';
 import { z } from 'zod';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { CHAT_COMPLETIONS_MINI_MODEL } from '@services/openai/constants';
 import { recordModelUsage, UsageCallbackHandler } from '@shared/ai';
 import { createExpense } from '../mongo';
@@ -88,7 +88,7 @@ export async function categorizeVendor(input: {
     const llm = await categorize(input);
     return { category: llm.category, type: llm.type };
   } catch (err) {
-    logger.warn(`categorizeVendor failed for "${input.vendor}", defaulting to other/card_alert: ${err instanceof Error ? err.message : String(err)}`);
+    logger.warn(`categorizeVendor failed for "${input.vendor}", defaulting to other/card_alert: ${getErrorMessage(err)}`);
     return { category: 'other', type: 'card_alert' };
   }
 }
@@ -105,7 +105,7 @@ export async function createManualExpense(input: ManualExpenseInput): Promise<Ex
     try {
       llm = await categorize(input);
     } catch (err) {
-      logger.warn(`Categorize failed, defaulting to "other"/"receipt": ${err instanceof Error ? err.message : String(err)}`);
+      logger.warn(`Categorize failed, defaulting to "other"/"receipt": ${getErrorMessage(err)}`);
       llm = { category: 'other', type: 'receipt', vendor: input.vendor.trim() };
     }
   }

--- a/src/shared/expenses/utils/manual-entry.ts
+++ b/src/shared/expenses/utils/manual-entry.ts
@@ -88,7 +88,7 @@ export async function categorizeVendor(input: {
     const llm = await categorize(input);
     return { category: llm.category, type: llm.type };
   } catch (err) {
-    logger.warn(`categorizeVendor failed for "${input.vendor}", defaulting to other/card_alert: ${err}`);
+    logger.warn(`categorizeVendor failed for "${input.vendor}", defaulting to other/card_alert: ${err instanceof Error ? err.message : String(err)}`);
     return { category: 'other', type: 'card_alert' };
   }
 }
@@ -105,7 +105,7 @@ export async function createManualExpense(input: ManualExpenseInput): Promise<Ex
     try {
       llm = await categorize(input);
     } catch (err) {
-      logger.warn(`Categorize failed, defaulting to "other"/"receipt": ${err}`);
+      logger.warn(`Categorize failed, defaulting to "other"/"receipt": ${err instanceof Error ? err.message : String(err)}`);
       llm = { category: 'other', type: 'receipt', vendor: input.vendor.trim() };
     }
   }

--- a/src/shared/map-service/api.ts
+++ b/src/shared/map-service/api.ts
@@ -10,7 +10,7 @@ const logger = new Logger('MapService');
 export async function generateMapImage(options: MapOptions, outputDir: string, filename: string): Promise<string> {
   const { lat, lon, zoom = DEFAULT_ZOOM, tileRange = DEFAULT_TILE_RANGE, tileSize = DEFAULT_TILE_SIZE, addMarker = false } = options;
 
-  logger.log(`Generating map image for Lat: ${lat}, Lon: ${lon}, Zoom: ${zoom}`);
+  logger.debug(`Generating map image for Lat: ${lat}, Lon: ${lon}, Zoom: ${zoom}`);
 
   const center = latLonToTile(lat, lon, zoom);
   const tilesX = tileRange * 2 + 1;
@@ -18,7 +18,7 @@ export async function generateMapImage(options: MapOptions, outputDir: string, f
   const width = tilesX * tileSize;
   const height = tilesY * tileSize;
 
-  logger.log(`Grid: ${tilesX}x${tilesY} tiles, Image: ${width}x${height} pixels`);
+  logger.debug(`Grid: ${tilesX}x${tilesY} tiles, Image: ${width}x${height} pixels`);
 
   const mapLayers: { input: Buffer; left: number; top: number }[] = [];
   const gridPromises = [];
@@ -34,7 +34,7 @@ export async function generateMapImage(options: MapOptions, outputDir: string, f
 
           const mapUrl = `${OPENSTREETMAP_TILE_URL}/${zoom}/${tx}/${ty}.png`;
 
-          logger.log(`Fetching: ${mapUrl}`);
+          logger.debug(`Fetching: ${mapUrl}`);
 
           const mapBuf = await fetchBuffer(mapUrl, { 'User-Agent': 'MMPS-MapService/1.0' });
 
@@ -80,7 +80,7 @@ export async function generateMapImage(options: MapOptions, outputDir: string, f
       left: 0,
     });
 
-    logger.log(`Added red marker at center (${markerX}, ${markerY})`);
+    logger.debug(`Added red marker at center (${markerX}, ${markerY})`);
   }
 
   const outputPath = path.join(outputDir, filename);
@@ -91,6 +91,6 @@ export async function generateMapImage(options: MapOptions, outputDir: string, f
     .composite(allLayers)
     .toFile(outputPath);
 
-  logger.log(`Map image saved to: ${outputPath}`);
+  logger.debug(`Map image saved to: ${outputPath}`);
   return outputPath;
 }

--- a/src/shared/map-service/utils/fetch-buffer.ts
+++ b/src/shared/map-service/utils/fetch-buffer.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 
 const logger = new Logger('fetch-buffer');
 
@@ -12,7 +12,7 @@ export async function fetchBuffer(url: string, headers: Record<string, string> =
     });
     return Buffer.from(response.data);
   } catch (err) {
-    logger.warn(`Failed to fetch tile ${url}: ${err instanceof Error ? err.message : String(err)}`);
+    logger.warn(`Failed to fetch tile ${url}: ${getErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/shared/map-service/utils/fetch-buffer.ts
+++ b/src/shared/map-service/utils/fetch-buffer.ts
@@ -12,7 +12,7 @@ export async function fetchBuffer(url: string, headers: Record<string, string> =
     });
     return Buffer.from(response.data);
   } catch (err) {
-    logger.warn(`Failed to fetch tile: ${url}, error - ${err}`);
+    logger.warn(`Failed to fetch tile ${url}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }

--- a/src/shared/wolt/mongo/subscription.ts
+++ b/src/shared/wolt/mongo/subscription.ts
@@ -1,5 +1,5 @@
 import { getMongoCollection } from '@core/mongo';
-import { Logger } from '@core/utils';
+import { getErrorMessage, Logger } from '@core/utils';
 import { Subscription } from '../types';
 import { DB_NAME } from './constants';
 
@@ -14,7 +14,7 @@ export async function getActiveSubscriptions(chatId: number = null): Promise<Sub
     if (chatId) filter['chatId'] = chatId;
     return subscriptionCollection.find(filter).toArray();
   } catch (err) {
-    logger.error(`getActiveSubscriptions - err: ${err instanceof Error ? err.message : String(err)}`);
+    logger.error(`getActiveSubscriptions - err: ${getErrorMessage(err)}`);
     return [];
   }
 }

--- a/src/shared/wolt/mongo/subscription.ts
+++ b/src/shared/wolt/mongo/subscription.ts
@@ -14,7 +14,7 @@ export async function getActiveSubscriptions(chatId: number = null): Promise<Sub
     if (chatId) filter['chatId'] = chatId;
     return subscriptionCollection.find(filter).toArray();
   } catch (err) {
-    logger.error(`getActiveSubscriptions - err: ${err}`);
+    logger.error(`getActiveSubscriptions - err: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }


### PR DESCRIPTION
## Why

We are about to set up log ingestion in Grafana/Loki, so all application logs need to be consistent, correctly leveled, and free of duplicate lines before they start being indexed. This PR is a full audit and cleanup of every Logger and raw console.* call in the app.

## What changed

- **Deduplicated logs.** Nested catch blocks in the notifier and the wolt scheduler emitted the same message twice for a single failure. Each layer now logs a distinct, accurate message (build vs send, retry vs give-up).
- **Demoted chatty logs to debug.** Per-iteration lines that fired dozens of times per run (weather provider selection, per-tile map fetches, rain-radar steps) were flooding the stream at log level. They are now debug, so production stays readable while the detail is still available when needed.
- **Routed raw console.* through Logger.** Calls in gmail, youtube-v3, and the earthquake tool bypassed the OTEL/Loki pipeline entirely. They now go through Logger so they actually reach Grafana, with appropriate levels.
- **Standardized error interpolation.** Error logging was split between two styles. All logger sites now use a safe instanceof Error check so objects never stringify to [object Object] and non-Error throws still render.
- **Removed redundant context prefixes.** Several messages manually prefixed the class/function name, which the Logger context field already carries; those were stripped to avoid double context in the indexed output.
- **Fixed a stale logger context** ('main.ts' in the entry point, which no longer matches the file).

Only logging behavior was touched. console.* sinks that must stay raw (the Logger itself, the Google Sheets override, and telemetry's diag logger) were intentionally left alone to avoid recursion.

## Validation

- tsc --noEmit clean
- eslint src 0 errors
- 580/580 tests pass
